### PR TITLE
Add showDashboard translations for embedded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismatic-io/translations",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/translations",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "license": "MIT",
       "devDependencies": {
         "prettier": "2.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismatic-io/translations",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/translations",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "devDependencies": {
         "prettier": "2.8.3",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/prismatic-io/translations.git"
   },
   "license": "MIT",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/prismatic-io/translations.git"
   },
   "license": "MIT",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/lib/shared/common.ts
+++ b/src/lib/shared/common.ts
@@ -26,6 +26,15 @@ export interface CommonPhrases {
 
   /** English: "This version has no publish message" */
   "common.noPublishedMessage": SimplePhrase;
+
+  /** English: "Disabled" */
+  "common.disabledStatus": SimplePhrase;
+
+  /** English: "Enabled" */
+  "common.enabledStatus": SimplePhrase;
+
+  /** English: "Not Enabled" */
+  "common.notEnabledStatus": SimplePhrase;
 }
 
 export const commonPhrases: CommonPhrases = {
@@ -37,4 +46,7 @@ export const commonPhrases: CommonPhrases = {
   "common.saveButton": "Save",
   "common.saving": "Saving",
   "common.unauthorized": "You must be authenticated.",
+  "common.disabledStatus": "Disabled",
+  "common.enabledStatus": "Enabled",
+  "common.notEnabledStatus": "Not Enabled",
 };

--- a/src/lib/shared/dataTable.ts
+++ b/src/lib/shared/dataTable.ts
@@ -51,6 +51,9 @@ export interface DataTablePhrases {
   /** English: "Labels" */
   "dataTable.labelsLabel": SimplePhrase;
 
+  /** English: "Last run" */
+  "dataTable.lastRunLabel": SimplePhrase;
+
   /** English: "Last triggered" */
   "dataTable.lastTriggeredAtLabel": SimplePhrase;
 
@@ -60,14 +63,23 @@ export interface DataTablePhrases {
   /** English: "Name" */
   "dataTable.nameLabel": SimplePhrase;
 
+  /** English: "Role" */
+  "dataTable.roleLabel": SimplePhrase;
+
   /** English: "Required" */
   "dataTable.requiredLabel": SimplePhrase;
 
   /** English: "Published" */
   "dataTable.publishedLabel": SimplePhrase;
 
+  /** English: "Status" */
+  "dataTable.statusLabel": SimplePhrase;
+
   /** English: "Timestamp" */
   "dataTable.timestampLabel": SimplePhrase;
+
+  /** English: "Triggered" */
+  "dataTable.triggeredLabel": SimplePhrase;
 
   /** English: "Triggers" */
   "dataTable.triggersLabel": SimplePhrase;
@@ -100,11 +112,15 @@ export const dataTablePhrases: DataTablePhrases = {
   "dataTable.integrationLabel": "Integration",
   "dataTable.labelsLabel": "Labels",
   "dataTable.lastTriggeredAtLabel": "Last triggered",
+  "dataTable.lastRunLabel": "Last run",
   "dataTable.messageLabel": "Message",
   "dataTable.nameLabel": "Name",
   "dataTable.requiredLabel": "Required",
+  "dataTable.roleLabel": "Role",
   "dataTable.publishedLabel": "Published",
+  "dataTable.statusLabel": "Status",
   "dataTable.timestampLabel": "Timestamp",
+  "dataTable.triggeredLabel": "Triggered",
   "dataTable.triggersLabel": "Triggers",
   "dataTable.typeLabel": "Type",
   "dataTable.versionLabel": "Version",

--- a/src/lib/shared/detail.ts
+++ b/src/lib/shared/detail.ts
@@ -1,6 +1,9 @@
 import { ComplexPhrase, SimplePhrase } from "../../types";
 
 export interface DetailPhrases {
+  /** English: "Attachments" */
+  "detail.attachmentsLabel": SimplePhrase;
+
   /** English: "Category" */
   "detail.categoryLabel": SimplePhrase;
 
@@ -21,6 +24,9 @@ export interface DetailPhrases {
 
   /** English: "Instance" */
   "detail.instanceLabel": SimplePhrase;
+
+  /** English: "Instances" */
+  "detail.instancesLabel": SimplePhrase;
 
   /** English: "Integration" */
   "detail.integrationLabel": SimplePhrase;
@@ -58,11 +64,21 @@ export interface DetailPhrases {
   /** English: "Activated but not configured" */
   "detail.statusUnconfiguredValue": SimplePhrase;
 
+  /** English: "Team Members" */
+  "detail.teamMembersLabel": SimplePhrase;
+
+  /** English: "Triggered Monitors" */
+  "detail.triggeredMonitorsLabel": SimplePhrase;
+
+  /** English: "Users" */
+  "detail.usersLabel": SimplePhrase;
+
   /** English: "Version" */
   "detail.versionLabel": SimplePhrase;
 }
 
 export const detailPhrases: DetailPhrases = {
+  "detail.attachmentsLabel": "Attachments",
   "detail.categoryLabel": "Category",
   "detail.configVariableLabel": "Config Variable",
   "detail.customerLabel": "Customer",
@@ -70,6 +86,7 @@ export const detailPhrases: DetailPhrases = {
   "detail.executionLabel": "Execution",
   "detail.executionText": "View in Execution Context",
   "detail.instanceLabel": "Instance",
+  "detail.instancesLabel": "Instances",
   "detail.integrationLabel": "Integration",
   "detail.labelsLabel": "Labels",
   "detail.lastRunLabel": "Last Run",
@@ -85,5 +102,8 @@ export const detailPhrases: DetailPhrases = {
   "detail.statusPausedValue": "Paused",
   "detail.statusRunningValue": "Running",
   "detail.statusUnconfiguredValue": "Activated but not configured",
+  "detail.teamMembersLabel": "Team Members",
+  "detail.triggeredMonitorsLabel": "Triggered Monitors",
+  "detail.usersLabel": "Users",
   "detail.versionLabel": "Version",
 };

--- a/src/lib/shared/filter.ts
+++ b/src/lib/shared/filter.ts
@@ -79,6 +79,24 @@ export interface FilterPhrases {
   /** English: "Attachments are a place to store documents that both customers and your team members can reference." */
   "emptyState.attachmentsText": SimplePhrase;
 
+  /** English: "Attachments" */
+  "emptyState.attachmentsTitle--embedded": SimplePhrase;
+
+  /** English: "Place to store integration documents that your team members can reference." */
+  "emptyState.attachmentsText--embedded": SimplePhrase;
+
+  /** English: "Components" */
+  "emptyState.componentsTitle": SimplePhrase;
+
+  /** English: "" */
+  "emptyState.componentsText": SimplePhrase;
+
+  /** English: "Components" */
+  "emptyState.componentsTitle--embedded": SimplePhrase;
+
+  /** English: "Here you will see any components that have been built specifically for your organization to use in the integration designer." */
+  "emptyState.componentsText--embedded": SimplePhrase;
+
   /** English: "Organization credential" */
   "emptyState.credentialsTitle": SimplePhrase;
 
@@ -163,6 +181,12 @@ export interface FilterPhrases {
   /** English: "Learn about integrations" */
   "emptyState.integrationsDocsButton": SimplePhrase;
 
+  /** English: "Integrations" */
+  "emptyState.integrationsTitle--embedded": SimplePhrase;
+
+  /** English: "Here you will see any integrations that your organization has built or can modify via the integration designer." */
+  "emptyState.integrationsText--embedded": SimplePhrase;
+
   /** English: "Integration marketplace" */
   "emptyState.integrationMarketplaceTitle": SimplePhrase;
 
@@ -207,6 +231,12 @@ export interface FilterPhrases {
 
   /** English: "Learn about log streams" */
   "emptyState.logStreamsDocsButton": SimplePhrase;
+
+  /** English: "Users" */
+  "emptyState.usersTitle--embedded": SimplePhrase;
+
+  /** English: "Here you will see users within your organization that have access to manage integrations." */
+  "emptyState.usersText--embedded": SimplePhrase;
 }
 
 export const filterPhrases: FilterPhrases = {
@@ -255,6 +285,18 @@ export const filterPhrases: FilterPhrases = {
   "emptyState.attachmentsTitle": "Customer attachments",
   "emptyState.attachmentsText":
     "Attachments are a place to store documents that both customers and your team members can reference.",
+
+  "emptyState.attachmentsTitle--embedded": "Atachments",
+  "emptyState.attachmentsText--embedded":
+    "Place to store integration documents that your team members can reference.",
+
+  // components empty state
+  "emptyState.componentsTitle": "Components",
+  "emptyState.componentsText": "",
+
+  "emptyState.componentsTitle--embedded": "Components",
+  "emptyState.componentsText--embedded":
+    "Here you will see any components that have been built specifically for your organization to use in the integration designer.",
 
   // credentials empty state
   "emptyState.credentialsTitle": "Organization credential",
@@ -312,6 +354,10 @@ export const filterPhrases: FilterPhrases = {
     "After building an integration, you can deploy it to one or more of your customers, or add it to your marketplace, where customers can activate it themselves.",
   "emptyState.integrationsDocsButton": "Learn about integrations",
 
+  "emptyState.integrationsTitle--embedded": "Integrations",
+  "emptyState.integrationsText--embedded":
+    "Here you will see any integrations that your organization has built or can modify via the integration designer.",
+
   // integration marketplace empty state
   "emptyState.integrationMarketplaceTitle": "Integration marketplace",
   "emptyState.integrationMarketplaceText":
@@ -342,4 +388,9 @@ export const filterPhrases: FilterPhrases = {
   "emptyState.logStreamsText":
     "Log streams allow you to send Prismatic logs to an external logging service (like DataDog or New Relic) or your own proprietary logging system.",
   "emptyState.logStreamsDocsButton": "Learn about log streams",
+
+  // users
+  "emptyState.usersTitle--embedded": "Users",
+  "emptyState.usersText--embedded":
+    "Here you will see users within your organization that have access to manage integrations.",
 };

--- a/src/lib/shared/index.ts
+++ b/src/lib/shared/index.ts
@@ -18,6 +18,7 @@ import { popoverPhrases, PopoverPhrases } from "./popover";
 import { tabPhrases, TabPhrases } from "./tab";
 import { tooltipPhrases, TooltipPhrases } from "./tooltip";
 import { triggerDetailsPhrases, TriggerDetailsPhrases } from "./triggerDetails";
+import { userPhrases, UserPhrases } from "./user";
 
 export { chipPhases, ChipPhases };
 export { commonPhrases, CommonPhrases };
@@ -36,6 +37,7 @@ export { popoverPhrases, PopoverPhrases };
 export { tabPhrases, TabPhrases };
 export { tooltipPhrases, TooltipPhrases };
 export { triggerDetailsPhrases, TriggerDetailsPhrases };
+export { userPhrases, UserPhrases };
 
 export type SharedPhrases = ChipPhases &
   CommonPhrases &
@@ -53,7 +55,8 @@ export type SharedPhrases = ChipPhases &
   PopoverPhrases &
   TabPhrases &
   TooltipPhrases &
-  TriggerDetailsPhrases;
+  TriggerDetailsPhrases &
+  UserPhrases;
 
 export const sharedPhrases: SharedPhrases = {
   ...chipPhases,
@@ -73,4 +76,5 @@ export const sharedPhrases: SharedPhrases = {
   ...tabPhrases,
   ...tooltipPhrases,
   ...triggerDetailsPhrases,
+  ...userPhrases,
 };

--- a/src/lib/shared/input.ts
+++ b/src/lib/shared/input.ts
@@ -7,6 +7,9 @@ export interface InputPhrases {
   /** English: "Alert Trigger" */
   "input.alertTriggerLabel": SimplePhrase;
 
+  /** English: "Allow embedded designer" */
+  "input.allowEmbeddedDesignerLabel": SimplePhrase;
+
   /** English: "Add API key" */
   "input.apiKeyAddButton": SimplePhrase;
 
@@ -127,6 +130,9 @@ export interface InputPhrases {
   /** English: "Marketplace Version" */
   "input.marketplaceVersionLabel": SimplePhrase;
 
+  /** English: "Name" */
+  "input.nameLabel": SimplePhrase;
+
   /** English: "No options found" */
   "input.noOptionsValue": SimplePhrase;
 
@@ -198,11 +204,18 @@ export interface InputPhrases {
 
   /** English: "Add value" */
   "input.valueAddButton": SimplePhrase;
+
+  /** English: "Upload a photo" */
+  "input.uploadPhotoLabel": SimplePhrase;
+
+  /** English: "Customer photos make it easier to recognize them throughout your account" */
+  "input.uploadCustomerLogoText": SimplePhrase;
 }
 
 export const inputPhrases: InputPhrases = {
   "input.alertMonitorLabel": "Monitor",
   "input.alertTriggerLabel": "Alert Trigger",
+  "input.allowEmbeddedDesignerLabel": "Allow embedded designer",
   "input.apiKeyAddButton": "Add API key",
   "input.apiKeyLabel": "API key",
   "input.apiKeyPlaceholder": "No API key configured",
@@ -247,6 +260,7 @@ export const inputPhrases: InputPhrases = {
   "input.logType.integrationExecutionValue": "Execution Only",
   "input.logTypeLabel": "Log type",
   "input.marketplaceVersionLabel": "Marketplace Version",
+  "input.nameLabel": "Name",
   "input.noOptionsValue": "No options found",
   "input.noneValue": "None",
   "input.objectFieldMapPlaceholder": "Edit",
@@ -271,4 +285,7 @@ export const inputPhrases: InputPhrases = {
   "input.valueAddButton": "Add value",
   "input.valueLabel": "Value",
   "input.valuePlaceholder": "Add a value",
+  "input.uploadPhotoLabel": "Upload a photo",
+  "input.uploadCustomerLogoText":
+    "Customer photos make it easier to recognize them throughout your account",
 };

--- a/src/lib/shared/tab.ts
+++ b/src/lib/shared/tab.ts
@@ -4,11 +4,29 @@ export interface TabPhrases {
   /** English: "Monitors" */
   "alertMonitorsTab.title": SimplePhrase;
 
+  /** English: "Attachments" */
+  "attachmentsTab.title": SimplePhrase;
+
+  /** English: "Components" */
+  "componentsTab.title": SimplePhrase;
+
   /** English: "User Configuration" */
   "configurationTab.title": SimplePhrase;
 
+  /** English: "Credentials" */
+  "credentialsTab.title": SimplePhrase;
+
+  /** English: "Details" */
+  "detailsTab.title": SimplePhrase;
+
   /** English: "Executions" */
   "executionsTab.title": SimplePhrase;
+
+  /** English: "Instances" */
+  "instancesTab.title": SimplePhrase;
+
+  /** English: "Integrations" */
+  "integrationsTab.title": SimplePhrase;
 
   /** English: "Payload" */
   "payloadTab.title": SimplePhrase;
@@ -16,6 +34,8 @@ export interface TabPhrases {
   /** English: "Summary" */
   "summaryTab.title": SimplePhrase;
 
+  /** English: "Users" */
+  "usersTab.title": SimplePhrase;
   /** English: "Test is running" */
   "testTab.testResults.banner.text--testIsRunning": SimplePhrase;
 
@@ -91,14 +111,25 @@ export interface TabPhrases {
 
   /** English: "Retry" */
   "retryTab.title": SimplePhrase;
+
+  /** English: "Team Members" */
+  "teamMembersTab.title": SimplePhrase;
 }
 
 export const tabPhrases: TabPhrases = {
   "alertMonitorsTab.title": "Monitors",
+  "attachmentsTab.title": "Attachments",
+  "componentsTab.title": "Components",
   "configurationTab.title": "User Configuration",
+  "credentialsTab.title": "Credentials",
+  "detailsTab.title": "Details",
   "executionsTab.title": "Executions",
+  "instancesTab.title": "Instances",
+  "integrationsTab.title": "Integrations",
   "payloadTab.title": "Payload",
   "summaryTab.title": "Summary",
+  "teamMembersTab.title": "Team Members",
+  "usersTab.title": "Users",
 
   // test tab
   "testTab.testResults.banner.text--testIsRunning": "Test is running",

--- a/src/lib/shared/tooltip.ts
+++ b/src/lib/shared/tooltip.ts
@@ -1,4 +1,4 @@
-import { SimplePhrase } from "../../types";
+import { ComplexPhrase, SimplePhrase } from "../../types";
 
 export interface TooltipPhrases {
   /** English: "Close" */
@@ -28,6 +28,11 @@ export interface TooltipPhrases {
   /** English: "Upgrade the Marketplace Configuration to this latest published version." */
   "tooltip.marketplaceVersion": SimplePhrase;
 
+  /** English: "A new version "v${latestVersion}" is available for integration." */
+  "tooltip.newIntegrationVersionAvailable": ComplexPhrase<{
+    latestVersion?: number;
+  }>;
+
   /** English: "Pass this API key via an HTTP header" */
   "tooltip.passApiKeyToHeader": SimplePhrase;
 
@@ -46,6 +51,9 @@ export const tooltipPhrases: TooltipPhrases = {
   "tooltip.copyUrl": "Copy URL to clipboard",
   "tooltip.marketplaceVersion":
     "Upgrade the Marketplace Configuration to this latest published version.",
+  "tooltip.newIntegrationVersionAvailable": {
+    _: `A new version "v%{latestVersion}" is available for integration.`,
+  },
   "tooltip.passApiKeyToHeader": "Pass this API key via an HTTP header",
   "tooltip.restoreDefault": "Restore default",
 };

--- a/src/lib/shared/user.ts
+++ b/src/lib/shared/user.ts
@@ -1,0 +1,42 @@
+import { SimplePhrase } from "../../types";
+
+export interface UserPhrases {
+  /** English: "Admin" */
+  "user.adminRole": SimplePhrase;
+
+  /** English: "Customer Manager" */
+  "user.customerManagerRole": SimplePhrase;
+
+  /** English: "Owner" */
+  "user.ownerRole": SimplePhrase;
+
+  /** English: "Guest" */
+  "user.guestRole": SimplePhrase;
+
+  /** English: "Member" */
+  "user.memberRole": SimplePhrase;
+
+  /** English: "Integrator" */
+  "user.integratorRole": SimplePhrase;
+
+  /** English: "Marketplace" */
+  "user.marketplaceRole": SimplePhrase;
+
+  /** English: "Marketplace User" */
+  "user.marketplaceUserRole": SimplePhrase;
+
+  /** English: "Third-Party" */
+  "user.thirdPartyRole": SimplePhrase;
+}
+
+export const userPhrases: UserPhrases = {
+  "user.adminRole": "Admin",
+  "user.customerManagerRole": "Customer Manager",
+  "user.guestRole": "Guest",
+  "user.integratorRole": "Integrator",
+  "user.marketplaceRole": "Marketplace",
+  "user.marketplaceUserRole": "Marketplace User",
+  "user.memberRole": "Member",
+  "user.ownerRole": "Owner",
+  "user.thirdPartyRole": "Third-Party",
+};

--- a/src/lib/unique/dashboard.ts
+++ b/src/lib/unique/dashboard.ts
@@ -1,0 +1,8 @@
+import { NamespacedSharedAndUniquePhrases } from "../../types";
+
+export interface DashboardPhrases {}
+
+export const dashboardPhrases: NamespacedSharedAndUniquePhrases<DashboardPhrases> =
+  {
+    "dashboard__filterBar.title": "Dashboard",
+  };

--- a/src/lib/unique/index.ts
+++ b/src/lib/unique/index.ts
@@ -4,6 +4,7 @@ import {
   AppMarketplaceNotFoundPhrases,
 } from "./app.marketplace-not-found";
 import { componentsPhrases, ComponentsPhrases } from "./components";
+import { dashboardPhrases, DashboardPhrases } from "./dashboard";
 import {
   integrationMarketplacePhrases,
   IntegrationMarketplacePhrases,
@@ -34,6 +35,7 @@ import { integrationsPhrases, IntegrationsPhrases } from "./integrations";
 export { notFoundPhrases, NotFoundPhrases };
 export { appMarketplaceNotFoundPhrases, AppMarketplaceNotFoundPhrases };
 export { componentsPhrases, ComponentsPhrases };
+export { dashboardPhrases, DashboardPhrases };
 export { integrationMarketplacePhrases, IntegrationMarketplacePhrases };
 export { integrationIdPhrases, IntegrationIdPhrases };
 export { integrationIdAlertMonitorsPhrases, IntegrationIdAlertMonitorsPhrases };
@@ -49,6 +51,7 @@ export { integrationsPhrases, IntegrationsPhrases };
 export type UniquePhrases = NotFoundPhrases &
   AppMarketplaceNotFoundPhrases &
   ComponentsPhrases &
+  DashboardPhrases &
   IntegrationMarketplacePhrases &
   IntegrationIdPhrases &
   IntegrationIdAlertMonitorsPhrases &
@@ -62,6 +65,7 @@ export const uniquePhrases: UniquePhrases = {
   ...notFoundPhrases,
   ...appMarketplaceNotFoundPhrases,
   ...componentsPhrases,
+  ...dashboardPhrases,
   ...integrationMarketplacePhrases,
   ...integrationIdPhrases,
   ...integrationIdAlertMonitorsPhrases,

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import { UniquePhrases } from "./lib/unique";
 
 export enum Namespace {
   COMPONENTS = "components",
+  DASHBOARD = "dashboard",
   INTEGRATIONS = "integrations",
   MARKETPLACE = "integration-marketplace",
   MARKETPLACE_INTEGRATION_ALERT_MONITORS = "integrations.id.alert-monitors",


### PR DESCRIPTION
https://app.shortcut.com/prismatic/story/15747/showdashboard-add-translations-for-customers-dashboard-pages

Add translations to new showDashboard pages: 

- Summary
- Integrations
- Components
- Instances
- Logs
- Monitors
- Users
- Executions