### PR TITLE
Fixed a typo in the embedded attachments title

### DIFF
--- a/src/lib/shared/filter.ts
+++ b/src/lib/shared/filter.ts
@@ -286,7 +286,7 @@ export const filterPhrases: FilterPhrases = {
   "emptyState.attachmentsText":
     "Attachments are a place to store documents that both customers and your team members can reference.",
 
-  "emptyState.attachmentsTitle--embedded": "Atachments",
+  "emptyState.attachmentsTitle--embedded": "Attachments",
   "emptyState.attachmentsText--embedded":
     "Place to store integration documents that your team members can reference.",
 


### PR DESCRIPTION
Corrected typo: "Atachments" > "Attachments"