### PR TITLE
Support branded elements: Convert SimplePhrases into ComplexPhrases

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 github-cli 2.42.1
-nodejs 18.17.1
+nodejs 18.18.2

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/prismatic-io/translations.git"
   },
   "license": "MIT",
-  "version": "1.11.8",
+  "version": "2.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/lib/shared/dataTable.ts
+++ b/src/lib/shared/dataTable.ts
@@ -37,7 +37,7 @@ export interface DataTablePhrases {
   /** English: "Input" */
   "dataTable.inputLabel": SimplePhrase;
 
-  /** English: "Inputs ${count}" */
+  /** English: "Inputs %{count}" */
   "dataTable.inputsText": ComplexPhrase<{
     count: number;
   }>;

--- a/src/lib/shared/dataTable.ts
+++ b/src/lib/shared/dataTable.ts
@@ -46,7 +46,9 @@ export interface DataTablePhrases {
   "dataTable.instanceLabel": SimplePhrase;
 
   /** English: "Integration" */
-  "dataTable.integrationLabel": SimplePhrase;
+  "dataTable.integrationLabel": ComplexPhrase<{
+    integrationSingular: string;
+  }> | SimplePhrase;
 
   /** English: "Labels" */
   "dataTable.labelsLabel": SimplePhrase;
@@ -109,7 +111,10 @@ export const dataTablePhrases: DataTablePhrases = {
   "dataTable.instanceLabel": "Instance",
   "dataTable.inputLabel": "Input",
   "dataTable.inputsText": { _: "%{count} inputs", count: 0 },
-  "dataTable.integrationLabel": "Integration",
+  "dataTable.integrationLabel": {
+    _: "%{integrationSingular}",
+    integrationSingular: "Integration"
+  },
   "dataTable.labelsLabel": "Labels",
   "dataTable.lastTriggeredAtLabel": "Last triggered",
   "dataTable.lastRunLabel": "Last run",

--- a/src/lib/shared/detail.ts
+++ b/src/lib/shared/detail.ts
@@ -32,7 +32,9 @@ export interface DetailPhrases {
   "detail.instancesLabel": SimplePhrase;
 
   /** English: "Integration" */
-  "detail.integrationLabel": SimplePhrase;
+  "detail.integrationLabel": ComplexPhrase<{
+    integrationSingular: string;
+  }> | SimplePhrase;
 
   /** English: "Labels" */
   "detail.labelsLabel": SimplePhrase;
@@ -127,7 +129,10 @@ export const detailPhrases: DetailPhrases = {
   "detail.executionslast24Hours": "Executions in the last 24 hours",
   "detail.instanceLabel": "Instance",
   "detail.instancesLabel": "Instances",
-  "detail.integrationLabel": "Integration",
+  "detail.integrationLabel": {
+    _: "%{integrationSingular}",
+    integrationSingular: "Integration"
+  },
   "detail.labelsLabel": "Labels",
   "detail.lastRunLabel": "Last Run",
   "detail.overviewLabel": "Overview",

--- a/src/lib/shared/dialog.ts
+++ b/src/lib/shared/dialog.ts
@@ -33,14 +33,18 @@ export interface DialogPhrases {
   /** English: "Webhook URLs" */
   "webhookUrlDialog.title": SimplePhrase;
 
-  /** English: "Remove Integration" */
-  "deleteUserConfigurationDialog.confirmButton": SimplePhrase;
+  /** English: "Remove ${integrationSingular}" */
+  "deleteUserConfigurationDialog.confirmButton": ComplexPhrase<{
+    integrationSingular: string;
+  }> | SimplePhrase;
 
   /** English: "Remove User Configuration" */
   "deleteUserConfigurationDialog.confirmButton--isAdmin": SimplePhrase;
 
-  /** English: "Deactivate Integration" */
-  "deleteUserConfigurationDialog.confirmButton--isCustomerMarketplaceUser": SimplePhrase;
+  /** English: "Deactivate ${integrationSingular}" */
+  "deleteUserConfigurationDialog.confirmButton--isCustomerMarketplaceUser": ComplexPhrase<{
+    integrationSingular: string;
+  }> | SimplePhrase;
 
   /** English: "Delete" */
   "deleteUserConfigurationDialog.openButton": SimplePhrase;
@@ -48,10 +52,12 @@ export interface DialogPhrases {
   /** English: "Are you sure?" */
   "deleteUserConfigurationDialog.title": SimplePhrase;
 
-  /** English: "This action cannot be undone. This will permanently delete the integration." */
-  "deleteUserConfigurationDialog.warningText": SimplePhrase;
+  /** English: "This action cannot be undone. This will permanently delete the ${integrationSingularLower}." */
+  "deleteUserConfigurationDialog.warningText": ComplexPhrase<{
+    integrationSingularLower: string;
+  }> | SimplePhrase;
 
-  /** English: "This action cannot be undone. This will permanently delete the configuration for %{email}." */
+  /** English: "This action cannot be undone. This will permanently delete the configuration for ${email}." */
   "deleteUserConfigurationDialog.warningText--isAdmin": ComplexPhrase<{
     email: string;
   }>;
@@ -59,23 +65,33 @@ export interface DialogPhrases {
   /** English: "User Configuration" */
   "deleteUserConfigurationDialog.options.userConfigurationButton": SimplePhrase;
 
-  /** English: "This action cannot be undone. This will deactivate the integration." */
-  "deleteUserConfigurationDialog.warningText--isCustomerMarketplaceUser": SimplePhrase;
+  /** English: "This action cannot be undone. This will deactivate the ${integrationSingularLower}." */
+  "deleteUserConfigurationDialog.warningText--isCustomerMarketplaceUser": ComplexPhrase<{
+    integrationSingularLower: string;
+  }> | SimplePhrase;
 
-  /** English: "This will remove all user configurations and deactivate the integration." */
-  "deleteUserConfigurationDialog.warningText--hasUserConfiguration": SimplePhrase;
+  /** English: "This will remove all user configurations and deactivate the ${integrationSingularLower}." */
+  "deleteUserConfigurationDialog.warningText--hasUserConfiguration": ComplexPhrase<{
+    integrationSingularLower: string;
+  }> | SimplePhrase;
 
-  /** English: "Deactivate Integration" */
-  "deactivateIntegrationDialog.confirmButton": SimplePhrase;
+  /** English: "Deactivate ${integrationSingular}" */
+  "deactivateIntegrationDialog.confirmButton": ComplexPhrase<{
+    integrationSingular: string;
+  }> | SimplePhrase;
 
-  /** English: "Deactivate Integration" */
-  "deactivateIntegrationDialog.openButton": SimplePhrase;
+  /** English: "Deactivate ${integrationSingular}" */
+  "deactivateIntegrationDialog.openButton": ComplexPhrase<{
+    integrationSingular: string;
+  }> | SimplePhrase;
 
   /** English: "Are you sure?" */
   "deactivateIntegrationDialog.title": SimplePhrase;
 
-  /** English: "This will deactivate this integration." */
-  "deactivateIntegrationDialog.warningText": SimplePhrase;
+  /** English: "This will deactivate this ${integrationSingularLower}." */
+  "deactivateIntegrationDialog.warningText": ComplexPhrase<{
+    integrationSingularLower: string;
+  }> | SimplePhrase;
 
   /** English: "Cancel" */
   "configurationWizardDialog.cancelButton": SimplePhrase;
@@ -92,7 +108,7 @@ export interface DialogPhrases {
   /** English: "Returning to the previous page will discard unsaved changes on this page. Are you sure?" */
   "configurationWizardDialog.previousWarningText": SimplePhrase;
 
-  /** English: "This page contains non-visible config variables that need to be set by %{organizationName} before continuing." */
+  /** English: "This page contains non-visible config variables that need to be set by ${organizationName} before continuing." */
   "configurationWizardDialog.missingEmbeddedConfigVariablesWarningText": ComplexPhrase<{
     organizationName: string;
   }>;
@@ -112,8 +128,9 @@ export interface DialogPhrases {
   /** English: "Update" */
   "apiKeyDialog.updateButton": SimplePhrase;
 
-  /** English: "Please contact %{organization} to configure this integration." */
+  /** English: "Please contact ${organization} to configure this ${integrationSingularLower}." */
   "activateIntegrationDialog.banner.text--isNotConfigurable": ComplexPhrase<{
+    integrationSingularLower?: string;
     organization?: string;
   }>;
 
@@ -135,8 +152,10 @@ export interface DialogPhrases {
   /** English: "View" */
   "activateIntegrationDialog.viewButton": SimplePhrase;
 
-  /** English: "Contact organization to configure this integration" */
-  "activateIntegrationDialog.marketplaceConfigurationError": SimplePhrase;
+  /** English: "Contact organization to configure this ${integrationSingularLower}" */
+  "activateIntegrationDialog.marketplaceConfigurationError": ComplexPhrase<{
+    integrationSingularLower: string;
+  }> | SimplePhrase;
 
   /** English: "View configuration" */
   "activateIntegrationDialog.viewConfiguration": SimplePhrase;
@@ -144,11 +163,15 @@ export interface DialogPhrases {
   /** English: "View details" */
   "activateIntegrationDialog.viewDetails": SimplePhrase;
 
-  /** English: "Pause integration" */
-  "activateIntegrationDialog.pauseIntegration": SimplePhrase;
+  /** English: "Pause ${integrationSingular}" */
+  "activateIntegrationDialog.pauseIntegration": ComplexPhrase<{
+    integrationSingular: string;
+  }> | SimplePhrase;
 
-  /** English: "Unpause integration" */
-  "activateIntegrationDialog.unpauseIntegration": SimplePhrase;
+  /** English: "Unpause ${integrationSingular}" */
+  "activateIntegrationDialog.unpauseIntegration": ComplexPhrase<{
+    integrationSingular: string;
+  }> | SimplePhrase;
 
   /** English: "Create user configuration" */
   "activateIntegrationDialog.createUserConfiguration": SimplePhrase;
@@ -174,8 +197,11 @@ export interface DialogPhrases {
   /** English: "Role" */
   "addUserDialog.roleLabel": SimplePhrase;
 
-  /** English: "This will remove this integration from the integration marketplace." */
-  "removeIntegrationDialog.warningText": SimplePhrase;
+  /** English: "This will remove this ${integrationSingular} from the ${marketplaceSingular}." */
+  "removeIntegrationDialog.warningText": ComplexPhrase<{
+    marketplaceSingular: string;
+    integrationSingularLower: string;
+  }> | SimplePhrase;
 
   /** English: "Initial Configuration" */
   "configurationWizardDialog.initialConfiguration": SimplePhrase;
@@ -208,21 +234,30 @@ export const dialogPhrases: DialogPhrases = {
   // activate integration dialog
   "activateIntegrationDialog.addButton": "Add Instance",
   "activateIntegrationDialog.banner.text--isNotConfigurable": {
-    _: "Please contact %{organization} to configure this integration.",
+    _: "Please contact %{organization} to configure this %{integrationSingularLower}.",
     organization: "your organization",
+    integrationSingularLower: "integration",
   },
   "activateIntegrationDialog.cancelButton": "Cancel",
   "activateIntegrationDialog.configureButton": "Configure",
   "activateIntegrationDialog.instancesText":
     "View an existing instance, or create a new one.",
   "activateIntegrationDialog.instancesTitle": "Instances",
-  "activateIntegrationDialog.marketplaceConfigurationError":
-    "Contact organization to configure this integration",
+  "activateIntegrationDialog.marketplaceConfigurationError": {
+    _: "Contact organization to configure this %{integrationSingularLower}",
+    integrationSingularLower: "integration",
+  },
   "activateIntegrationDialog.viewButton": "View",
   "activateIntegrationDialog.viewConfiguration": "View configuration",
   "activateIntegrationDialog.viewDetails": "View details",
-  "activateIntegrationDialog.pauseIntegration": "Pause integration",
-  "activateIntegrationDialog.unpauseIntegration": "Unpause integration",
+  "activateIntegrationDialog.pauseIntegration": {
+    _: "Pause %{integrationSingular}",
+    integrationSingular: "Integration",
+  },
+  "activateIntegrationDialog.unpauseIntegration": {
+    _: "Unpause %{integrationSingular}",
+    integrationSingular: "Integration",
+  },
   "activateIntegrationDialog.createUserConfiguration":
     "Create user configuration",
   "activateIntegrationDialog.editUserConfiguration": "Edit user configuration",
@@ -231,32 +266,51 @@ export const dialogPhrases: DialogPhrases = {
     "Delete user configuration",
 
   // delete user configuration dialog
-  "deleteUserConfigurationDialog.confirmButton": "Remove Integration",
+  "deleteUserConfigurationDialog.confirmButton": {
+    _: "Remove %{integrationSingular}",
+    integrationSingular: "Integration",
+  },
   "deleteUserConfigurationDialog.confirmButton--isAdmin":
     "Remove User Configuration",
   "deleteUserConfigurationDialog.openButton": "Delete",
   "deleteUserConfigurationDialog.title": "Are you sure?",
-  "deleteUserConfigurationDialog.warningText":
-    "This action cannot be undone. This will permanently delete the integration.",
+  "deleteUserConfigurationDialog.warningText": {
+    _: "This action cannot be undone. This will permanently delete the %{integrationSingularLower}.",
+    integrationSingularLower: "integration",
+  },
   "deleteUserConfigurationDialog.warningText--isAdmin": {
     _: "This action cannot be undone. This will permanently delete the configuration for %{email}.",
     email: "",
   },
-  "deleteUserConfigurationDialog.confirmButton--isCustomerMarketplaceUser":
-    "Deactivate Integration",
+  "deleteUserConfigurationDialog.confirmButton--isCustomerMarketplaceUser": {
+    _: "Deactivate %{integrationSingular}",
+    integrationSingular: "Integration",
+  },
   "deleteUserConfigurationDialog.options.userConfigurationButton":
     "User Configuration",
-  "deleteUserConfigurationDialog.warningText--isCustomerMarketplaceUser":
-    "This action cannot be undone. This will deactivate the integration.",
-  "deleteUserConfigurationDialog.warningText--hasUserConfiguration":
-    "This will remove all user configurations and deactivate the integration.",
+  "deleteUserConfigurationDialog.warningText--isCustomerMarketplaceUser": {
+    _: "This action cannot be undone. This will deactivate the %{integrationSingularLower}.",
+    integrationSingularLower: "integration",
+  },
+  "deleteUserConfigurationDialog.warningText--hasUserConfiguration": {
+    _: "This will remove all user configurations and deactivate the %{integrationSingularLower}.",
+    integrationSingularLower: "integration",
+  },
 
   // deactivate integration dialog
-  "deactivateIntegrationDialog.openButton": "Deactivate Integration",
-  "deactivateIntegrationDialog.confirmButton": "Deactivate Integration",
+  "deactivateIntegrationDialog.openButton": {
+    _: "Deactivate %{integrationSingular}",
+    integrationSingular: "Integration",
+  },
+  "deactivateIntegrationDialog.confirmButton": {
+    _: "Deactivate %{integrationSingular}",
+    integrationSingular: "Integration",
+  },
   "deactivateIntegrationDialog.title": "Are you sure?",
-  "deactivateIntegrationDialog.warningText":
-    "This will deactivate this integration.",
+  "deactivateIntegrationDialog.warningText": {
+    _: "This will deactivate this %{integrationSingularLower}.",
+    integrationSingularLower: "integration",
+  },
 
   // confirmation wizard dialog
   "configurationWizardDialog.cancelButton": "Cancel",
@@ -284,8 +338,11 @@ export const dialogPhrases: DialogPhrases = {
   "addUserDialog.roleLabel": "Role",
 
   // remove integration dialog
-  "removeIntegrationDialog.warningText":
-    "This will remove this integration from the integration marketplace.",
+  "removeIntegrationDialog.warningText": {
+    _: "This will remove this %{integrationSingularLower} from the %{marketplaceSingular}.",
+    marketplaceSingular: "Marketplace",
+    integrationSingularLower: "integration",
+  },
 
   // initial configuration dialog
   "configurationWizardDialog.initialConfiguration": "Initial Configuration",

--- a/src/lib/shared/dialog.ts
+++ b/src/lib/shared/dialog.ts
@@ -33,7 +33,7 @@ export interface DialogPhrases {
   /** English: "Webhook URLs" */
   "webhookUrlDialog.title": SimplePhrase;
 
-  /** English: "Remove ${integrationSingular}" */
+  /** English: "Remove %{integrationSingular}" */
   "deleteUserConfigurationDialog.confirmButton": ComplexPhrase<{
     integrationSingular: string;
   }> | SimplePhrase;
@@ -41,7 +41,7 @@ export interface DialogPhrases {
   /** English: "Remove User Configuration" */
   "deleteUserConfigurationDialog.confirmButton--isAdmin": SimplePhrase;
 
-  /** English: "Deactivate ${integrationSingular}" */
+  /** English: "Deactivate %{integrationSingular}" */
   "deleteUserConfigurationDialog.confirmButton--isCustomerMarketplaceUser": ComplexPhrase<{
     integrationSingular: string;
   }> | SimplePhrase;
@@ -52,12 +52,12 @@ export interface DialogPhrases {
   /** English: "Are you sure?" */
   "deleteUserConfigurationDialog.title": SimplePhrase;
 
-  /** English: "This action cannot be undone. This will permanently delete the ${integrationSingularLower}." */
+  /** English: "This action cannot be undone. This will permanently delete the %{integrationSingularLower}." */
   "deleteUserConfigurationDialog.warningText": ComplexPhrase<{
     integrationSingularLower: string;
   }> | SimplePhrase;
 
-  /** English: "This action cannot be undone. This will permanently delete the configuration for ${email}." */
+  /** English: "This action cannot be undone. This will permanently delete the configuration for %{email}." */
   "deleteUserConfigurationDialog.warningText--isAdmin": ComplexPhrase<{
     email: string;
   }>;
@@ -65,22 +65,22 @@ export interface DialogPhrases {
   /** English: "User Configuration" */
   "deleteUserConfigurationDialog.options.userConfigurationButton": SimplePhrase;
 
-  /** English: "This action cannot be undone. This will deactivate the ${integrationSingularLower}." */
+  /** English: "This action cannot be undone. This will deactivate the %{integrationSingularLower}." */
   "deleteUserConfigurationDialog.warningText--isCustomerMarketplaceUser": ComplexPhrase<{
     integrationSingularLower: string;
   }> | SimplePhrase;
 
-  /** English: "This will remove all user configurations and deactivate the ${integrationSingularLower}." */
+  /** English: "This will remove all user configurations and deactivate the %{integrationSingularLower}." */
   "deleteUserConfigurationDialog.warningText--hasUserConfiguration": ComplexPhrase<{
     integrationSingularLower: string;
   }> | SimplePhrase;
 
-  /** English: "Deactivate ${integrationSingular}" */
+  /** English: "Deactivate %{integrationSingular}" */
   "deactivateIntegrationDialog.confirmButton": ComplexPhrase<{
     integrationSingular: string;
   }> | SimplePhrase;
 
-  /** English: "Deactivate ${integrationSingular}" */
+  /** English: "Deactivate %{integrationSingular}" */
   "deactivateIntegrationDialog.openButton": ComplexPhrase<{
     integrationSingular: string;
   }> | SimplePhrase;
@@ -88,7 +88,7 @@ export interface DialogPhrases {
   /** English: "Are you sure?" */
   "deactivateIntegrationDialog.title": SimplePhrase;
 
-  /** English: "This will deactivate this ${integrationSingularLower}." */
+  /** English: "This will deactivate this %{integrationSingularLower}." */
   "deactivateIntegrationDialog.warningText": ComplexPhrase<{
     integrationSingularLower: string;
   }> | SimplePhrase;
@@ -108,7 +108,7 @@ export interface DialogPhrases {
   /** English: "Returning to the previous page will discard unsaved changes on this page. Are you sure?" */
   "configurationWizardDialog.previousWarningText": SimplePhrase;
 
-  /** English: "This page contains non-visible config variables that need to be set by ${organizationName} before continuing." */
+  /** English: "This page contains non-visible config variables that need to be set by %{organizationName} before continuing." */
   "configurationWizardDialog.missingEmbeddedConfigVariablesWarningText": ComplexPhrase<{
     organizationName: string;
   }>;
@@ -128,7 +128,7 @@ export interface DialogPhrases {
   /** English: "Update" */
   "apiKeyDialog.updateButton": SimplePhrase;
 
-  /** English: "Please contact ${organization} to configure this ${integrationSingularLower}." */
+  /** English: "Please contact %{organization} to configure this %{integrationSingularLower}." */
   "activateIntegrationDialog.banner.text--isNotConfigurable": ComplexPhrase<{
     integrationSingularLower?: string;
     organization?: string;
@@ -152,7 +152,7 @@ export interface DialogPhrases {
   /** English: "View" */
   "activateIntegrationDialog.viewButton": SimplePhrase;
 
-  /** English: "Contact organization to configure this ${integrationSingularLower}" */
+  /** English: "Contact organization to configure this %{integrationSingularLower}" */
   "activateIntegrationDialog.marketplaceConfigurationError": ComplexPhrase<{
     integrationSingularLower: string;
   }> | SimplePhrase;
@@ -163,12 +163,12 @@ export interface DialogPhrases {
   /** English: "View details" */
   "activateIntegrationDialog.viewDetails": SimplePhrase;
 
-  /** English: "Pause ${integrationSingular}" */
+  /** English: "Pause %{integrationSingular}" */
   "activateIntegrationDialog.pauseIntegration": ComplexPhrase<{
     integrationSingular: string;
   }> | SimplePhrase;
 
-  /** English: "Unpause ${integrationSingular}" */
+  /** English: "Unpause %{integrationSingular}" */
   "activateIntegrationDialog.unpauseIntegration": ComplexPhrase<{
     integrationSingular: string;
   }> | SimplePhrase;
@@ -197,7 +197,7 @@ export interface DialogPhrases {
   /** English: "Role" */
   "addUserDialog.roleLabel": SimplePhrase;
 
-  /** English: "This will remove this ${integrationSingular} from the ${marketplaceSingular}." */
+  /** English: "This will remove this %{integrationSingularLower} from the %{marketplaceSingular}." */
   "removeIntegrationDialog.warningText": ComplexPhrase<{
     marketplaceSingular: string;
     integrationSingularLower: string;

--- a/src/lib/shared/filter.ts
+++ b/src/lib/shared/filter.ts
@@ -1,11 +1,15 @@
-import { SimplePhrase } from "../../types";
+import { ComplexPhrase, SimplePhrase } from "../../types";
 
 export interface FilterPhrases {
-  /** English: "Integration Marketplace" */
-  "filterBar.breadcrumb.integrationMarketplace": SimplePhrase;
+  /** English: "Marketplace" */
+  "filterBar.breadcrumb.integrationMarketplace": ComplexPhrase<{
+    marketplaceSingular: string;
+  }> | SimplePhrase;
 
-  /** English: "Active Integrations" */
-  "filterBar.breadcrumb.activeIntegrations": SimplePhrase;
+  /** English: "Active ${integrationPlural}" */
+  "filterBar.breadcrumb.activeIntegrations": ComplexPhrase<{
+    integrationPlural: string;
+  }> | SimplePhrase;
 
   /** English: "Instances" */
   "filterBar.breadcrumb.instances": SimplePhrase;
@@ -24,9 +28,6 @@ export interface FilterPhrases {
 
   /** English: "Auto-polling is only available with default filters." */
   "filterBar.refreshTooltip": SimplePhrase;
-
-  /** English: "[Empty String]" */
-  "filterBar.title": SimplePhrase;
 
   /** English: "[Empty String]" */
   "filterResults.placeholderCta": SimplePhrase;
@@ -58,8 +59,10 @@ export interface FilterPhrases {
   /** English: "Not all alerts are bad - you can also alert people when an instance is enabled, or when it runs successfully." */
   "emptyState.alertMonitorsTextTwo": SimplePhrase;
 
-  /** English: "Here you will see any alerts that have been configured for you integrations." */
-  "emptyState.alertMonitorsText--customer": SimplePhrase;
+  /** English: "Here you will see any alerts that have been configured for your ${integrationPluralLower}." */
+  "emptyState.alertMonitorsText--customer": ComplexPhrase<{
+    integrationPluralLower: string;
+  }> | SimplePhrase;
 
   /** English: "Learn about alert monitors" */
   "emptyState.alertMonitorsDocsButton": SimplePhrase;
@@ -82,8 +85,10 @@ export interface FilterPhrases {
   /** English: "Attachments" */
   "emptyState.attachmentsTitle--embedded": SimplePhrase;
 
-  /** English: "Place to store integration documents that your team members can reference." */
-  "emptyState.attachmentsText--embedded": SimplePhrase;
+  /** English: "Place to store ${integrationSingularLower} documents that your team members can reference." */
+  "emptyState.attachmentsText--embedded": ComplexPhrase<{
+    integrationSingularLower: string;
+  }> | SimplePhrase;
 
   /** English: "Components" */
   "emptyState.componentsTitle": SimplePhrase;
@@ -94,14 +99,18 @@ export interface FilterPhrases {
   /** English: "Components" */
   "emptyState.componentsTitle--embedded": SimplePhrase;
 
-  /** English: "Here you will see any components that have been built specifically for your organization to use in the integration designer." */
-  "emptyState.componentsText--embedded": SimplePhrase;
+  /** English: "Here you will see any components that have been built specifically for your organization to use in the ${integrationSingular} designer." */
+  "emptyState.componentsText--embedded": ComplexPhrase<{
+    integrationSingular: string;
+  }> | SimplePhrase;
 
   /** English: "Organization credential" */
   "emptyState.credentialsTitle": SimplePhrase;
 
-  /** English: "Credentials that are saved at an organization level are either applicable to all of your customers (like a shared API key), or they're used by your team members for testing integrations." */
-  "emptyState.credentialsText": SimplePhrase;
+  /** English: "Credentials that are saved at an organization level are either applicable to all of your customers (like a shared API key), or they're used by your team members for testing ${integrationPlural}." */
+  "emptyState.credentialsText": ComplexPhrase<{
+    integrationPlural: string;
+  }> | SimplePhrase;
 
   /** English: "Learn About Credentials" */
   "emptyState.credentialsDocsButton": SimplePhrase;
@@ -112,17 +121,25 @@ export interface FilterPhrases {
   /** English: "Customer credentials" */
   "emptyState.customerCredentialsTitle": SimplePhrase;
 
-  /** English: "When you deploy an instance of an integration to a customer, that customer's credentials are used to connect to third-party apps and services." */
-  "emptyState.customerCredentialsText": SimplePhrase;
+  /** English: "When you deploy an instance of ${integrationSingularArticle} ${integrationSingularLower} to a customer, that customer's credentials are used to connect to third-party apps and services." */
+  "emptyState.customerCredentialsText": ComplexPhrase<{
+    integrationSingularLower: string;
+    integrationSingularArticle: string;
+  }> | SimplePhrase;
 
   /** English: "Customers" */
   "emptyState.customersTitle": SimplePhrase;
 
-  /** English: "You'll manage your customers here. You can deploy any number of your integrations to each customer, or they can activate integrations themselves through the marketplace." */
-  "emptyState.customersText": SimplePhrase;
+  /** English: "You'll manage your customers here. You can deploy any number of your ${integrationPluralLower} to each customer, or they can activate ${integrationPlural} themselves through the ${marketplaceSingular}." */
+  "emptyState.customersText": ComplexPhrase<{
+    integrationPluralLower: string;
+    marketplaceSingular: string;
+  }> | SimplePhrase;
 
-  /** English: "From each customer record, you can deploy or reconfigure their integrations, review logs, manage their users, and more." */
-  "emptyState.customersTextTwo": SimplePhrase;
+  /** English: "From each customer record, you can deploy or reconfigure their ${integrationPluralLower}, review logs, manage their users, and more." */
+  "emptyState.customersTextTwo": ComplexPhrase<{
+    integrationPluralLower: string;
+  }> | SimplePhrase;
 
   /** English: "Learn about customers" */
   "emptyState.customersDocsButton": SimplePhrase;
@@ -133,20 +150,27 @@ export interface FilterPhrases {
   /** English: "You can invite your customers to log in to Prismatic, so they can manage instances deployed to them and review their own executions and logs." */
   "emptyState.customerUsersText": SimplePhrase;
 
-  /** English: "Note: You do not need to add customer users to Prismatic if your users authenticate through an embedded marketplace." */
-  "emptyState.customerUsersTextTwo": SimplePhrase;
+  /** English: "Note: You do not need to add customer users to Prismatic if your users authenticate through an embedded ${marketplaceSingular}." */
+  "emptyState.customerUsersTextTwo": ComplexPhrase<{
+    marketplaceSingular: string;
+  }> | SimplePhrase;
 
   /** English: "Learn about customer users" */
   "emptyState.customerUsersDocsButton": SimplePhrase;
 
-  /** English: "Embedded marketplace user authentication" */
-  "emptyState.customerUsersDocsButtonTwo": SimplePhrase;
+  /** English: "Embedded ${marketplaceSingular} user authentication" */
+  "emptyState.customerUsersDocsButtonTwo": ComplexPhrase<{
+    marketplaceSingular: string;
+  }> | SimplePhrase;
 
   /** English: "Instance executions" */
   "emptyState.executionsTitle": SimplePhrase;
 
-  /** English: "Each time an instance of an integration runs, that's called an execution. Execution details are available here." */
-  "emptyState.executionsText": SimplePhrase;
+  /** English: "Each time an instance of ${integrationSingularArticle} ${integrationSingularLower} runs, that's called an execution. Execution details are available here." */
+  "emptyState.executionsText": ComplexPhrase<{
+    integrationSingularLower: string;
+    integrationSingularArticle: string;
+  }> | SimplePhrase;
 
   /** English: "You can inspect execution logs and results of each step of the execution, which is useful for support and debugging purposes." */
   "emptyState.executionsTextTwo": SimplePhrase;
@@ -157,53 +181,91 @@ export interface FilterPhrases {
   /** English: "Instances" */
   "emptyState.instancesTitle": SimplePhrase;
 
-  /** English: "In Prismatic, integrations are reusable - they can be deployed to multiple customers and configured to behave differently from one customer to the next." */
-  "emptyState.instancesText": SimplePhrase;
+  /** English: "In Prismatic, ${integrationPluralLower} are reusable - they can be deployed to multiple customers and configured to behave differently from one customer to the next." */
+  "emptyState.instancesText": ComplexPhrase<{
+    integrationPluralLower: string;
+  }> | SimplePhrase;
 
-  /** English: "An instance is an integration that has been deployed to a specific customer using customer-specific configuration." */
-  "emptyState.instancesTextTwo": SimplePhrase;
+  /** English: "An instance is ${integrationSingularArticle} ${integrationSingularLower} that has been deployed to a specific customer using customer-specific configuration." */
+  "emptyState.instancesTextTwo": ComplexPhrase<{
+    integrationSingularLower: string;
+    integrationSingularArticle: string;
+  }> | SimplePhrase;
 
-  /** English: "Here you will see any integrations that have been configured in the marketplace or deployed directly to your organization." */
-  "emptyState.instancesText--customer": SimplePhrase;
+  /** English: "Here you will see any ${integrationPluralLower} that have been configured in the ${marketplaceSingular} or deployed directly to your organization." */
+  "emptyState.instancesText--customer": ComplexPhrase<{
+    integrationPluralLower: string;
+    marketplaceSingular: string;
+  }> | SimplePhrase;
 
   /** English: "Learn about instances" */
   "emptyState.instancesDocsButton": SimplePhrase;
 
-  /** English: "Integrations" */
-  "emptyState.integrationsTitle": SimplePhrase;
+  /** English: "${integrationPlural}" */
+  "emptyState.integrationsTitle": ComplexPhrase<{
+    integrationPlural: string;
+  }> | SimplePhrase;
 
-  /** English: "Integrations are reusable workflows that connect your product to the other apps and services your customers use." */
-  "emptyState.integrationsText": SimplePhrase;
+  /** English: "${integrationPlural} are reusable workflows that connect your product to the other apps and services your customers use." */
+  "emptyState.integrationsText": ComplexPhrase<{
+    integrationPlural: string;
+  }> | SimplePhrase;
 
-  /** English: "After building an integration, you can deploy it to one or more of your customers, or add it to your marketplace, where customers can activate it themselves." */
-  "emptyState.integrationsTextTwo": SimplePhrase;
+  /** English: "After building ${integrationSingularArticle} ${integrationSingularLower}, you can deploy it to one or more of your customers, or add it to your ${marketplaceSingular}, where customers can activate it themselves." */
+  "emptyState.integrationsTextTwo": ComplexPhrase<{
+    marketplaceSingular: string;
+    integrationSingularLower: string;
+    integrationSingularArticle: string;
+  }> | SimplePhrase;
 
-  /** English: "Learn about integrations" */
-  "emptyState.integrationsDocsButton": SimplePhrase;
+  /** English: "Learn about ${integrationPluralLower}" */
+  "emptyState.integrationsDocsButton": ComplexPhrase<{
+    integrationPluralLower: string;
+  }> | SimplePhrase;
 
-  /** English: "Integrations" */
-  "emptyState.integrationsTitle--embedded": SimplePhrase;
+  /** English: "${integrationPlural}" */
+  "emptyState.integrationsTitle--embedded": ComplexPhrase<{
+    integrationPlural: string;
+  }> | SimplePhrase;
 
-  /** English: "Here you will see any integrations that your organization has built or can modify via the integration designer." */
-  "emptyState.integrationsText--embedded": SimplePhrase;
+  /** English: "Here you will see any ${integrationPluralLower} that your organization has built or can modify via the ${integrationSingularLower} designer." */
+  "emptyState.integrationsText--embedded": ComplexPhrase<{
+    integrationPluralLower: string;
+    integrationSingularLower: string;
+  }> | SimplePhrase;
 
-  /** English: "Integration marketplace" */
-  "emptyState.integrationMarketplaceTitle": SimplePhrase;
+  /** English: "Marketplace" by default. Will be overwritten by organization branded element values. */
+  "emptyState.integrationMarketplaceTitle": ComplexPhrase<{
+    marketplaceSingular: string;
+  }> | SimplePhrase;
 
-  /** English: "Your integration marketplace is where your customers go to browse your integration offerings and self-activate the ones they want. It can be white-labeled and embedded in your app to create a native integration experience." */
-  "emptyState.integrationMarketplaceText": SimplePhrase;
+  /** English: "Your ${marketplaceSingular} is where your customers go to browse your ${integrationSingularLower} offerings and self-activate the ones they want. It can be white-labeled and embedded in your app to create a native ${integrationSingular} experience." */
+  "emptyState.integrationMarketplaceText": ComplexPhrase<{
+    marketplaceSingular: string;
+    integrationSingularLower: string;
+  }> | SimplePhrase;
 
-  /** English: "Here is where you set up which integrations are included in your marketplace and how they appear." */
-  "emptyState.integrationMarketplaceTextTwo": SimplePhrase;
+  /** English: "Here is where you set up which ${integrationPluralLower} are included in your ${marketplaceSingular} and how they appear." */
+  "emptyState.integrationMarketplaceTextTwo": ComplexPhrase<{
+    marketplaceSingular: string;
+    integrationPluralLower: string;
+  }> | SimplePhrase;
 
-  /** English: "The integration marketplace displays integrations that have been enabled or available for configuration." */
-  "emptyState.integrationMarketplaceText--customer": SimplePhrase;
+  /** English: "The ${marketplaceSingular} displays ${integrationPluralLower} that have been enabled or available for configuration." */
+  "emptyState.integrationMarketplaceText--customer": ComplexPhrase<{
+    marketplaceSingular: string;
+    integrationPluralLower: string;
+  }> | SimplePhrase;
 
-  /** English: "Learn about the integration marketplace" */
-  "emptyState.integrationMarketplaceDocsButton": SimplePhrase;
+  /** English: "Learn about the ${marketplaceSingular}" */
+  "emptyState.integrationMarketplaceDocsButton": ComplexPhrase<{
+    marketplaceSingular: string;
+  }> | SimplePhrase;
 
-  /** English: "Embedding marketplace in your app" */
-  "emptyState.integrationMarketplaceDocsButtonTwo": SimplePhrase;
+  /** English: "Embedding ${marketplaceSingular} in your app" */
+  "emptyState.integrationMarketplaceDocsButtonTwo": ComplexPhrase<{
+    marketplaceSingular: string;
+  }> | SimplePhrase;
 
   /** English: "Logs" */
   "emptyState.logsTitle": SimplePhrase;
@@ -211,14 +273,18 @@ export interface FilterPhrases {
   /** English: "If actions in your deployed instances generate log messages, you'll find those here." */
   "emptyState.logsText": SimplePhrase;
 
-  /** English: "From this page you can search and filter logs so you can keep tabs on exactly what's going on with your customers' live integrations." */
-  "emptyState.logsTextTwo": SimplePhrase;
+  /** English: "From this page you can search and filter logs so you can keep tabs on exactly what's going on with your customers' live ${integrationPluralLower}." */
+  "emptyState.logsTextTwo": ComplexPhrase<{
+    integrationPluralLower: string;
+  }> | SimplePhrase;
 
   /** English: "If actions in your deployed instances generate log messages, you'll find those here." */
   "emptyState.logsText--customer": SimplePhrase;
 
-  /** English: "From this page you can search and filter logs so you can keep tabs on exactly what's going on with your integrations." */
-  "emptyState.logsTextTwo--customer": SimplePhrase;
+  /** English: "From this page you can search and filter logs so you can keep tabs on exactly what's going on with your ${integrationPluralLower}." */
+  "emptyState.logsTextTwo--customer": ComplexPhrase<{
+    integrationPluralLower: string;
+  }> | SimplePhrase;
 
   /** English: "Learn about logs" */
   "emptyState.logsDocsButton": SimplePhrase;
@@ -235,8 +301,10 @@ export interface FilterPhrases {
   /** English: "Users" */
   "emptyState.usersTitle--embedded": SimplePhrase;
 
-  /** English: "Here you will see users within your organization that have access to manage integrations." */
-  "emptyState.usersText--embedded": SimplePhrase;
+  /** English: "Here you will see users within your organization that have access to manage ${integrationPluralLower}." */
+  "emptyState.usersText--embedded": ComplexPhrase<{
+    integrationPluralLower: string;
+  }> | SimplePhrase;
 
   /** English: "Instance monitors" */
   "emptyState.instanceMonitorsTitle": SimplePhrase;
@@ -244,16 +312,21 @@ export interface FilterPhrases {
 
 export const filterPhrases: FilterPhrases = {
   // filter bar
-  "filterBar.breadcrumb.activeIntegrations": "Active Integrations",
+  "filterBar.breadcrumb.activeIntegrations": {
+    _: "%{integrationPlural}",
+    integrationPlural: "Active Integrations",
+  },
   "filterBar.breadcrumb.instances": "Instances",
   "filterBar.breadcrumb.components": "Components",
-  "filterBar.breadcrumb.integrationMarketplace": "Integration Marketplace",
+  "filterBar.breadcrumb.integrationMarketplace": {
+    _: "%{marketplaceSingular}",
+    marketplaceSingular: "Marketplace",
+  },
   "filterBar.clearFiltersButton": "Clear filters",
   "filterBar.openFiltersButton": "Filter",
   "filterBar.refreshButton": "Refresh",
   "filterBar.refreshTooltip":
     "Auto-polling is only available with default filters.",
-  "filterBar.title": "",
 
   // filter results
   "filterResults.placeholderCta": "",
@@ -274,8 +347,10 @@ export const filterPhrases: FilterPhrases = {
     "If an instance encounters an error (maybe a third-party API is down), you probably want to be alerted. You can configure monitoring and alerting rules to notify your team or even customers via text, email, or webhook when certain events occur.",
   "emptyState.alertMonitorsTextTwo":
     "Not all alerts are bad - you can also alert people when an instance is enabled, or when it runs successfully.",
-  "emptyState.alertMonitorsText--customer":
-    "Here you will see any alerts that have been configured for you integrations.",
+  "emptyState.alertMonitorsText--customer": {
+    _: "Here you will see any alerts that have been configured for your %{integrationPluralLower}.",
+    integrationPluralLower: "integrations",
+  },
   "emptyState.alertMonitorsDocsButton": "Learn about alert monitors",
 
   // alert webhook empty state
@@ -290,100 +365,168 @@ export const filterPhrases: FilterPhrases = {
     "Attachments are a place to store documents that both customers and your team members can reference.",
 
   "emptyState.attachmentsTitle--embedded": "Attachments",
-  "emptyState.attachmentsText--embedded":
-    "Place to store integration documents that your team members can reference.",
+  "emptyState.attachmentsText--embedded": {
+    _: "Place to store %{integrationSingularLower} documents that your team members can reference.",
+    integrationSingularLower: "integration",
+  },
 
   // components empty state
   "emptyState.componentsTitle": "Components",
   "emptyState.componentsText": "",
 
   "emptyState.componentsTitle--embedded": "Components",
-  "emptyState.componentsText--embedded":
-    "Here you will see any components that have been built specifically for your organization to use in the integration designer.",
+  "emptyState.componentsText--embedded": {
+    _: "Here you will see any components that have been built specifically for your organization to use in the %{integrationSingular} designer.",
+    integrationSingular: "Integration",
+  },
 
   // credentials empty state
   "emptyState.credentialsTitle": "Organization credential",
-  "emptyState.credentialsText":
-    "Credentials that are saved at an organization level are either applicable to all of your customers (like a shared API key), or they're used by your team members for testing integrations.",
+  "emptyState.credentialsText": {
+    _: "Credentials that are saved at an organization level are either applicable to all of your customers (like a shared API key), or they're used by your team members for testing %{integrationPlural}.",
+    integrationPlural: "Integrations",
+  },
   "emptyState.credentialsDocsButton": "Learn About Credentials",
   "emptyState.credentialsDocsButtonTwo": "OAuth 2.0 in Prismatic",
 
   // customer credentials empty state
   "emptyState.customerCredentialsTitle": "Customer credentials",
   "emptyState.customerCredentialsText":
-    "When you deploy an instance of an integration to a customer, that customer's credentials are used to connect to third-party apps and services.",
+    {
+      _: "When you deploy an instance of %{integrationSingularArticle} %{integrationSingularLower} to a customer, that customer's credentials are used to connect to third-party apps and services.",
+      integrationSingularLower: "integration",
+      integrationSingularArticle: "an",
+    },
 
   // customers empty state
   "emptyState.customersTitle": "Customers",
-  "emptyState.customersText":
-    "You'll manage your customers here. You can deploy any number of your integrations to each customer, or they can activate integrations themselves through the marketplace.",
-  "emptyState.customersTextTwo":
-    "From each customer record, you can deploy or reconfigure their integrations, review logs, manage their users, and more.",
+  "emptyState.customersText": {
+    _: "You'll manage your customers here. You can deploy any number of your %{integrationPlural} to each customer, or they can activate %{integrationPluralLower} themselves through the %{marketplaceSingular}.",
+    marketplaceSingular: "Marketplace",
+    integrationPluralLower: "integrations",
+  },
+  "emptyState.customersTextTwo": {
+    _: "From each customer record, you can deploy or reconfigure their %{integrationPluralLower}, review logs, manage their users, and more.",
+    integrationPluralLower: "integrations",
+  },
   "emptyState.customersDocsButton": "Learn about customers",
 
   // customer users empty state
   "emptyState.customerUsersTitle": "Customer users",
   "emptyState.customerUsersText":
     "You can invite your customers to log in to Prismatic, so they can manage instances deployed to them and review their own executions and logs.",
-  "emptyState.customerUsersTextTwo":
-    "Note: You do not need to add customer users to Prismatic if your users authenticate through an embedded marketplace.",
+  "emptyState.customerUsersTextTwo": {
+    _: "Note: You do not need to add customer users to Prismatic if your users authenticate through an embedded %{marketplaceSingular}.",
+    marketplaceSingular: "Marketplace",
+  },
   "emptyState.customerUsersDocsButton": "Learn about customer users",
-  "emptyState.customerUsersDocsButtonTwo":
-    "Embedded marketplace user authentication",
+  "emptyState.customerUsersDocsButtonTwo": {
+    _: "Embedded %{marketplaceSingular} user authentication",
+    marketplaceSingular: "Marketplace",
+  },
 
   // executions empty state
   "emptyState.executionsTitle": "Instance executions",
-  "emptyState.executionsText":
-    "Each time an instance of an integration runs, that's called an execution. Execution details are available here.",
+  "emptyState.executionsText": {
+    _: "Each time an instance of %{integrationSingularArticle} %{integrationSingularLower} runs, that's called an execution. Execution details are available here.",
+    integrationSingularLower: "integration",
+    integrationSingularArticle: "an",
+  },
   "emptyState.executionsTextTwo":
     "You can inspect execution logs and results of each step of the execution, which is useful for support and debugging purposes.",
   "emptyState.executionsDocsButton": "Learn about instance executions",
 
   // instances empty state
   "emptyState.instancesTitle": "Instances",
-  "emptyState.instancesText":
-    "In Prismatic, integrations are reusable - they can be deployed to multiple customers and configured to behave differently from one customer to the next.",
-  "emptyState.instancesTextTwo":
-    "An instance is an integration that has been deployed to a specific customer using customer-specific configuration.",
-  "emptyState.instancesText--customer":
-    "Here you will see any integrations that have been configured in the marketplace or deployed directly to your organization.",
+  "emptyState.instancesText": {
+    _: "In Prismatic, %{integrationPluralLower} are reusable - they can be deployed to multiple customers and configured to behave differently from one customer to the next.",
+    integrationPluralLower: "integrations",
+  },
+  "emptyState.instancesTextTwo": {
+    _: "An instance is %{integrationSingularArticle} %{integrationSingularLower} that has been deployed to a specific customer using customer-specific configuration.",
+    integrationSingularLower: "integration",
+    integrationSingularArticle: "an",
+  },
+  "emptyState.instancesText--customer": {
+    _: "Here you will see any %{integrationPluralLower} that have been configured in the %{marketplaceSingular} or deployed directly to your organization.",
+    integrationPluralLower: "integrations",
+    marketplaceSingular: "Marketplace",
+  },
   "emptyState.instancesDocsButton": "Learn about instances",
 
   // integrations empty state
-  "emptyState.integrationsTitle": "Integrations",
-  "emptyState.integrationsText":
-    "Integrations are reusable workflows that connect your product to the other apps and services your customers use.",
-  "emptyState.integrationsTextTwo":
-    "After building an integration, you can deploy it to one or more of your customers, or add it to your marketplace, where customers can activate it themselves.",
-  "emptyState.integrationsDocsButton": "Learn about integrations",
+  "emptyState.integrationsTitle": {
+    _: "%{integrationPlural}",
+    integrationPlural: "Integrations",
+  },
+  "emptyState.integrationsText": {
+    _: "%{integrationPlural} are reusable workflows that connect your product to the other apps and services your customers use.",
+    integrationPlural: "Integrations",
+  },
+  "emptyState.integrationsTextTwo": {
+    _: "After building %{integrationSingularArticle} %{integrationSingularLower}, you can deploy it to one or more of your customers, or add it to your %{marketplaceSingular}, where customers can activate it themselves.",
+    marketplaceSingular: "Marketplace",
+    integrationSingularLower: "integration",
+    integrationSingularArticle: "an",
+  },
+  "emptyState.integrationsDocsButton": {
+    _: "Learn about %{integrationPluralLower}",
+    integrationPluralLower: "integrations",
+  },
 
-  "emptyState.integrationsTitle--embedded": "Integrations",
-  "emptyState.integrationsText--embedded":
-    "Here you will see any integrations that your organization has built or can modify via the integration designer.",
+  "emptyState.integrationsTitle--embedded": {
+    _: "%{integrationPlural}",
+    integrationPlural: "Integrations",
+  },
+  "emptyState.integrationsText--embedded": {
+    _: "Here you will see any %{integrationPluralLower} that your organization has built or can modify via the %{integrationSingularLower} designer.",
+    integrationPluralLower: "integrations",
+    integrationSingularLower: "integration",
+  },
 
   // integration marketplace empty state
-  "emptyState.integrationMarketplaceTitle": "Integration marketplace",
-  "emptyState.integrationMarketplaceText":
-    "Your integration marketplace is where your customers go to browse your integration offerings and self-activate the ones they want. It can be white-labeled and embedded in your app to create a native integration experience.",
-  "emptyState.integrationMarketplaceTextTwo":
-    "Here is where you set up which integrations are included in your marketplace and how they appear.",
-  "emptyState.integrationMarketplaceText--customer":
-    "The integration marketplace displays integrations that have been enabled or available for configuration.",
-  "emptyState.integrationMarketplaceDocsButton":
-    "Learn about the integration marketplace",
-  "emptyState.integrationMarketplaceDocsButtonTwo":
-    "Embedding marketplace in your app",
+  "emptyState.integrationMarketplaceTitle": {
+    _: "%{marketplaceSingular}",
+    marketplaceSingular: "Marketplace",
+  },
+  "emptyState.integrationMarketplaceText": {
+    _: "Your %{marketplaceSingular} is where your customers go to browse your %{integrationSingularLower} offerings and self-activate the ones they want. It can be white-labeled and embedded in your app to create a native %{integrationSingularLower} experience.",
+    marketplaceSingular: "Marketplace",
+    integrationSingularLower: "integration",
+  },
+  "emptyState.integrationMarketplaceTextTwo": {
+    _: "Here is where you set up which %{integrationPluralLower} are included in your %{marketplaceSingular} and how they appear.",
+    marketplaceSingular: "Marketplace",
+    integrationPluralLower: "integrations",
+  },
+  "emptyState.integrationMarketplaceText--customer": {
+    _: "The %{marketplaceSingular} displays %{integrationPluralLower} that have been enabled or available for configuration.",
+    marketplaceSingular: "Marketplace",
+    integrationPluralLower: "integrations",
+  },
+  "emptyState.integrationMarketplaceDocsButton": {
+    _: "Learn about the %{marketplaceSingular}",
+    marketplaceSingular: "Marketplace",
+  },
+  "emptyState.integrationMarketplaceDocsButtonTwo": {
+    _: "Embedding %{marketplaceSingular} in your app",
+    marketplaceSingular: "Marketplace",
+  },
 
   // logs empty state
   "emptyState.logsTitle": "Logs",
   "emptyState.logsText":
     "If actions in your deployed instances generate log messages, you'll find those here.",
-  "emptyState.logsTextTwo":
-    "From this page you can search and filter logs so you can keep tabs on exactly what's going on with your customers' live integrations.",
+  "emptyState.logsTextTwo": {
+    _: "From this page you can search and filter logs so you can keep tabs on exactly what's going on with your customers' live %{integrationPluralLower}.",
+    integrationPluralLower: "integrations",
+  },
   "emptyState.logsText--customer":
     "If actions in your deployed instances generate log messages, you'll find those here.",
-  "emptyState.logsTextTwo--customer":
-    "From this page you can search and filter logs so you can keep tabs on exactly what's going on with your integrations.",
+  "emptyState.logsTextTwo--customer": {
+    _: "From this page you can search and filter logs so you can keep tabs on exactly what's going on with your %{integrationPluralLower}.",
+    integrationPluralLower: "integrations",
+  },
   "emptyState.logsDocsButton": "Learn about logs",
 
   // log streams empty state
@@ -394,8 +537,10 @@ export const filterPhrases: FilterPhrases = {
 
   // users
   "emptyState.usersTitle--embedded": "Users",
-  "emptyState.usersText--embedded":
-    "Here you will see users within your organization that have access to manage integrations.",
+  "emptyState.usersText--embedded": {
+    _: "Here you will see users within your organization that have access to manage %{integrationPluralLower}.",
+    integrationPluralLower: "integrations",
+  },
 
   // instance monitors
   "emptyState.instanceMonitorsTitle": "Instance monitors",

--- a/src/lib/shared/filter.ts
+++ b/src/lib/shared/filter.ts
@@ -6,7 +6,7 @@ export interface FilterPhrases {
     marketplaceSingular: string;
   }> | SimplePhrase;
 
-  /** English: "Active ${integrationPlural}" */
+  /** English: "Active %{integrationPlural}" */
   "filterBar.breadcrumb.activeIntegrations": ComplexPhrase<{
     integrationPlural: string;
   }> | SimplePhrase;
@@ -59,7 +59,7 @@ export interface FilterPhrases {
   /** English: "Not all alerts are bad - you can also alert people when an instance is enabled, or when it runs successfully." */
   "emptyState.alertMonitorsTextTwo": SimplePhrase;
 
-  /** English: "Here you will see any alerts that have been configured for your ${integrationPluralLower}." */
+  /** English: "Here you will see any alerts that have been configured for your %{integrationPluralLower}." */
   "emptyState.alertMonitorsText--customer": ComplexPhrase<{
     integrationPluralLower: string;
   }> | SimplePhrase;
@@ -85,7 +85,7 @@ export interface FilterPhrases {
   /** English: "Attachments" */
   "emptyState.attachmentsTitle--embedded": SimplePhrase;
 
-  /** English: "Place to store ${integrationSingularLower} documents that your team members can reference." */
+  /** English: "Place to store %{integrationSingularLower} documents that your team members can reference." */
   "emptyState.attachmentsText--embedded": ComplexPhrase<{
     integrationSingularLower: string;
   }> | SimplePhrase;
@@ -99,7 +99,7 @@ export interface FilterPhrases {
   /** English: "Components" */
   "emptyState.componentsTitle--embedded": SimplePhrase;
 
-  /** English: "Here you will see any components that have been built specifically for your organization to use in the ${integrationSingular} designer." */
+  /** English: "Here you will see any components that have been built specifically for your organization to use in the %{integrationSingular} designer." */
   "emptyState.componentsText--embedded": ComplexPhrase<{
     integrationSingular: string;
   }> | SimplePhrase;
@@ -107,7 +107,7 @@ export interface FilterPhrases {
   /** English: "Organization credential" */
   "emptyState.credentialsTitle": SimplePhrase;
 
-  /** English: "Credentials that are saved at an organization level are either applicable to all of your customers (like a shared API key), or they're used by your team members for testing ${integrationPlural}." */
+  /** English: "Credentials that are saved at an organization level are either applicable to all of your customers (like a shared API key), or they're used by your team members for testing %{integrationPlural}." */
   "emptyState.credentialsText": ComplexPhrase<{
     integrationPlural: string;
   }> | SimplePhrase;
@@ -121,7 +121,7 @@ export interface FilterPhrases {
   /** English: "Customer credentials" */
   "emptyState.customerCredentialsTitle": SimplePhrase;
 
-  /** English: "When you deploy an instance of ${integrationSingularArticle} ${integrationSingularLower} to a customer, that customer's credentials are used to connect to third-party apps and services." */
+  /** English: "When you deploy an instance of %{integrationSingularArticle} %{integrationSingularLower} to a customer, that customer's credentials are used to connect to third-party apps and services." */
   "emptyState.customerCredentialsText": ComplexPhrase<{
     integrationSingularLower: string;
     integrationSingularArticle: string;
@@ -130,13 +130,13 @@ export interface FilterPhrases {
   /** English: "Customers" */
   "emptyState.customersTitle": SimplePhrase;
 
-  /** English: "You'll manage your customers here. You can deploy any number of your ${integrationPluralLower} to each customer, or they can activate ${integrationPlural} themselves through the ${marketplaceSingular}." */
+  /** English: "You'll manage your customers here. You can deploy any number of your %{integrationPluralLower} to each customer, or they can activate %{integrationPlural} themselves through the %{marketplaceSingular}." */
   "emptyState.customersText": ComplexPhrase<{
     integrationPluralLower: string;
     marketplaceSingular: string;
   }> | SimplePhrase;
 
-  /** English: "From each customer record, you can deploy or reconfigure their ${integrationPluralLower}, review logs, manage their users, and more." */
+  /** English: "From each customer record, you can deploy or reconfigure their %{integrationPluralLower}, review logs, manage their users, and more." */
   "emptyState.customersTextTwo": ComplexPhrase<{
     integrationPluralLower: string;
   }> | SimplePhrase;
@@ -150,7 +150,7 @@ export interface FilterPhrases {
   /** English: "You can invite your customers to log in to Prismatic, so they can manage instances deployed to them and review their own executions and logs." */
   "emptyState.customerUsersText": SimplePhrase;
 
-  /** English: "Note: You do not need to add customer users to Prismatic if your users authenticate through an embedded ${marketplaceSingular}." */
+  /** English: "Note: You do not need to add customer users to Prismatic if your users authenticate through an embedded %{marketplaceSingular}." */
   "emptyState.customerUsersTextTwo": ComplexPhrase<{
     marketplaceSingular: string;
   }> | SimplePhrase;
@@ -158,7 +158,7 @@ export interface FilterPhrases {
   /** English: "Learn about customer users" */
   "emptyState.customerUsersDocsButton": SimplePhrase;
 
-  /** English: "Embedded ${marketplaceSingular} user authentication" */
+  /** English: "Embedded %{marketplaceSingular} user authentication" */
   "emptyState.customerUsersDocsButtonTwo": ComplexPhrase<{
     marketplaceSingular: string;
   }> | SimplePhrase;
@@ -166,7 +166,7 @@ export interface FilterPhrases {
   /** English: "Instance executions" */
   "emptyState.executionsTitle": SimplePhrase;
 
-  /** English: "Each time an instance of ${integrationSingularArticle} ${integrationSingularLower} runs, that's called an execution. Execution details are available here." */
+  /** English: "Each time an instance of %{integrationSingularArticle} %{integrationSingularLower} runs, that's called an execution. Execution details are available here." */
   "emptyState.executionsText": ComplexPhrase<{
     integrationSingularLower: string;
     integrationSingularArticle: string;
@@ -181,18 +181,18 @@ export interface FilterPhrases {
   /** English: "Instances" */
   "emptyState.instancesTitle": SimplePhrase;
 
-  /** English: "In Prismatic, ${integrationPluralLower} are reusable - they can be deployed to multiple customers and configured to behave differently from one customer to the next." */
+  /** English: "In Prismatic, %{integrationPluralLower} are reusable - they can be deployed to multiple customers and configured to behave differently from one customer to the next." */
   "emptyState.instancesText": ComplexPhrase<{
     integrationPluralLower: string;
   }> | SimplePhrase;
 
-  /** English: "An instance is ${integrationSingularArticle} ${integrationSingularLower} that has been deployed to a specific customer using customer-specific configuration." */
+  /** English: "An instance is %{integrationSingularArticle} %{integrationSingularLower} that has been deployed to a specific customer using customer-specific configuration." */
   "emptyState.instancesTextTwo": ComplexPhrase<{
     integrationSingularLower: string;
     integrationSingularArticle: string;
   }> | SimplePhrase;
 
-  /** English: "Here you will see any ${integrationPluralLower} that have been configured in the ${marketplaceSingular} or deployed directly to your organization." */
+  /** English: "Here you will see any %{integrationPluralLower} that have been configured in the %{marketplaceSingular} or deployed directly to your organization." */
   "emptyState.instancesText--customer": ComplexPhrase<{
     integrationPluralLower: string;
     marketplaceSingular: string;
@@ -201,34 +201,34 @@ export interface FilterPhrases {
   /** English: "Learn about instances" */
   "emptyState.instancesDocsButton": SimplePhrase;
 
-  /** English: "${integrationPlural}" */
+  /** English: "%{integrationPlural}" */
   "emptyState.integrationsTitle": ComplexPhrase<{
     integrationPlural: string;
   }> | SimplePhrase;
 
-  /** English: "${integrationPlural} are reusable workflows that connect your product to the other apps and services your customers use." */
+  /** English: "%{integrationPlural} are reusable workflows that connect your product to the other apps and services your customers use." */
   "emptyState.integrationsText": ComplexPhrase<{
     integrationPlural: string;
   }> | SimplePhrase;
 
-  /** English: "After building ${integrationSingularArticle} ${integrationSingularLower}, you can deploy it to one or more of your customers, or add it to your ${marketplaceSingular}, where customers can activate it themselves." */
+  /** English: "After building %{integrationSingularArticle} %{integrationSingularLower}, you can deploy it to one or more of your customers, or add it to your %{marketplaceSingular}, where customers can activate it themselves." */
   "emptyState.integrationsTextTwo": ComplexPhrase<{
     marketplaceSingular: string;
     integrationSingularLower: string;
     integrationSingularArticle: string;
   }> | SimplePhrase;
 
-  /** English: "Learn about ${integrationPluralLower}" */
+  /** English: "Learn about %{integrationPluralLower}" */
   "emptyState.integrationsDocsButton": ComplexPhrase<{
     integrationPluralLower: string;
   }> | SimplePhrase;
 
-  /** English: "${integrationPlural}" */
+  /** English: "%{integrationPlural}" */
   "emptyState.integrationsTitle--embedded": ComplexPhrase<{
     integrationPlural: string;
   }> | SimplePhrase;
 
-  /** English: "Here you will see any ${integrationPluralLower} that your organization has built or can modify via the ${integrationSingularLower} designer." */
+  /** English: "Here you will see any %{integrationPluralLower} that your organization has built or can modify via the %{integrationSingularLower} designer." */
   "emptyState.integrationsText--embedded": ComplexPhrase<{
     integrationPluralLower: string;
     integrationSingularLower: string;
@@ -239,30 +239,30 @@ export interface FilterPhrases {
     marketplaceSingular: string;
   }> | SimplePhrase;
 
-  /** English: "Your ${marketplaceSingular} is where your customers go to browse your ${integrationSingularLower} offerings and self-activate the ones they want. It can be white-labeled and embedded in your app to create a native ${integrationSingular} experience." */
+  /** English: "Your %{marketplaceSingular} is where your customers go to browse your %{integrationSingularLower} offerings and self-activate the ones they want. It can be white-labeled and embedded in your app to create a native %{integrationSingular} experience." */
   "emptyState.integrationMarketplaceText": ComplexPhrase<{
     marketplaceSingular: string;
     integrationSingularLower: string;
   }> | SimplePhrase;
 
-  /** English: "Here is where you set up which ${integrationPluralLower} are included in your ${marketplaceSingular} and how they appear." */
+  /** English: "Here is where you set up which %{integrationPluralLower} are included in your %{marketplaceSingular} and how they appear." */
   "emptyState.integrationMarketplaceTextTwo": ComplexPhrase<{
     marketplaceSingular: string;
     integrationPluralLower: string;
   }> | SimplePhrase;
 
-  /** English: "The ${marketplaceSingular} displays ${integrationPluralLower} that have been enabled or available for configuration." */
+  /** English: "The %{marketplaceSingular} displays %{integrationPluralLower} that have been enabled or available for configuration." */
   "emptyState.integrationMarketplaceText--customer": ComplexPhrase<{
     marketplaceSingular: string;
     integrationPluralLower: string;
   }> | SimplePhrase;
 
-  /** English: "Learn about the ${marketplaceSingular}" */
+  /** English: "Learn about the %{marketplaceSingular}" */
   "emptyState.integrationMarketplaceDocsButton": ComplexPhrase<{
     marketplaceSingular: string;
   }> | SimplePhrase;
 
-  /** English: "Embedding ${marketplaceSingular} in your app" */
+  /** English: "Embedding %{marketplaceSingular} in your app" */
   "emptyState.integrationMarketplaceDocsButtonTwo": ComplexPhrase<{
     marketplaceSingular: string;
   }> | SimplePhrase;
@@ -273,7 +273,7 @@ export interface FilterPhrases {
   /** English: "If actions in your deployed instances generate log messages, you'll find those here." */
   "emptyState.logsText": SimplePhrase;
 
-  /** English: "From this page you can search and filter logs so you can keep tabs on exactly what's going on with your customers' live ${integrationPluralLower}." */
+  /** English: "From this page you can search and filter logs so you can keep tabs on exactly what's going on with your customers' live %{integrationPluralLower}." */
   "emptyState.logsTextTwo": ComplexPhrase<{
     integrationPluralLower: string;
   }> | SimplePhrase;
@@ -281,7 +281,7 @@ export interface FilterPhrases {
   /** English: "If actions in your deployed instances generate log messages, you'll find those here." */
   "emptyState.logsText--customer": SimplePhrase;
 
-  /** English: "From this page you can search and filter logs so you can keep tabs on exactly what's going on with your ${integrationPluralLower}." */
+  /** English: "From this page you can search and filter logs so you can keep tabs on exactly what's going on with your %{integrationPluralLower}." */
   "emptyState.logsTextTwo--customer": ComplexPhrase<{
     integrationPluralLower: string;
   }> | SimplePhrase;
@@ -301,7 +301,7 @@ export interface FilterPhrases {
   /** English: "Users" */
   "emptyState.usersTitle--embedded": SimplePhrase;
 
-  /** English: "Here you will see users within your organization that have access to manage ${integrationPluralLower}." */
+  /** English: "Here you will see users within your organization that have access to manage %{integrationPluralLower}." */
   "emptyState.usersText--embedded": ComplexPhrase<{
     integrationPluralLower: string;
   }> | SimplePhrase;
@@ -401,7 +401,7 @@ export const filterPhrases: FilterPhrases = {
   // customers empty state
   "emptyState.customersTitle": "Customers",
   "emptyState.customersText": {
-    _: "You'll manage your customers here. You can deploy any number of your %{integrationPlural} to each customer, or they can activate %{integrationPluralLower} themselves through the %{marketplaceSingular}.",
+    _: "You'll manage your customers here. You can deploy any number of your %{integrationPluralLower} to each customer, or they can activate %{integrationPluralLower} themselves through the %{marketplaceSingular}.",
     marketplaceSingular: "Marketplace",
     integrationPluralLower: "integrations",
   },

--- a/src/lib/shared/input.ts
+++ b/src/lib/shared/input.ts
@@ -25,7 +25,7 @@ export interface InputPhrases {
   /** English: "Category" */
   "input.categoryLabel": SimplePhrase;
 
-  /** English: "Category can only be updated in the ${integrationSingularLower} details." */
+  /** English: "Category can only be updated in the %{integrationSingularLower} details." */
   "input.categoryDisabledHelper.integration": ComplexPhrase<{
     integrationSingularLower: string;
   }> | SimplePhrase;
@@ -57,7 +57,7 @@ export interface InputPhrases {
   /** English: "Description" */
   "input.descriptionLabel": SimplePhrase;
 
-  /** English: "Description can only be updated in the ${integrationSingularLower} details." */
+  /** English: "Description can only be updated in the %{integrationSingularLower} details." */
   "input.descriptionDisabledHelper.integration": ComplexPhrase<{
     integrationSingularLower: string;
   }> | SimplePhrase;
@@ -107,20 +107,20 @@ export interface InputPhrases {
   /** English: "Include customer components" */
   "input.includeCustomerComponentsLabel": SimplePhrase;
 
-  /** English: "Include customer ${integrationPlural}" */
+  /** English: "Include customer %{integrationPluralLower}" */
   "input.includeCustomerIntegrationsLabel": ComplexPhrase<{
-    integrationPlural: string;
+    integrationPluralLower: string;
   }> | SimplePhrase;
 
   /** English: "Instance" */
   "input.instanceLabel": SimplePhrase;
 
-  /** English: "${integrationSingular}" */
+  /** English: "%{integrationSingular}" */
   "input.integrationLabel": ComplexPhrase<{
     integrationSingular: string;
   }> | SimplePhrase;
 
-  /** English: "${integrationSingular} version" */
+  /** English: "%{integrationSingular} version" */
   "input.integrationVersionLabel": ComplexPhrase<{
     integrationSingular: string;
   }> | SimplePhrase;
@@ -155,13 +155,13 @@ export interface InputPhrases {
   /** English: "Log type" */
   "input.logTypeLabel": SimplePhrase;
 
-  /** English: "${marketplaceSingular} version" */
+  /** English: "%{marketplaceSingular} version" */
   "input.marketplaceVersionLabel": ComplexPhrase<{ marketplaceSingular?: string }>;
 
   /** English: "Name" */
   "input.nameLabel": SimplePhrase;
 
-  /** English: "Name can only be updated in the ${integrationSingularLower} details." */
+  /** English: "Name can only be updated in the %{integrationSingularLower} details." */
   "input.nameDisabledHelper.integration": ComplexPhrase<{
     integrationSingularLower: string;
   }> | SimplePhrase;
@@ -311,8 +311,8 @@ export const inputPhrases: InputPhrases = {
   "input.apiKeyLabel": "API key",
   "input.apiKeyPlaceholder": "No API key configured",
   "input.categoryDisabledHelper.integration": {
-    _: "Category can only be updated in the ${integrationSingularLower} details.",
-    integrationSingularLower: "Integration",
+    _: "Category can only be updated in the %{integrationSingularLower} details.",
+    integrationSingularLower: "integration",
   },
   "input.categoryLabel": "Category",
   "input.codePlaceholder": "Edit",
@@ -325,8 +325,8 @@ export const inputPhrases: InputPhrases = {
   "input.dateTimeError": "There was an error",
   "input.defaultValueLabel": "Default value",
   "input.descriptionDisabledHelper.integration": {
-    _: "Description can only be updated in the ${integrationSingularLower} details.",
-    integrationSingularLower: "Integration",
+    _: "Description can only be updated in the %{integrationSingularLower} details.",
+    integrationSingularLower: "integration",
   },
   "input.descriptionLabel": "Description",
   "input.disableLogsLabel": "Disable logs",
@@ -347,8 +347,8 @@ export const inputPhrases: InputPhrases = {
   "input.headersValueLabel": "Value",
   "input.includeCustomerComponentsLabel": "Include customer components",
   "input.includeCustomerIntegrationsLabel": {
-    _: "Include customer %{integrationPlural}",
-    integrationPlural: "Integrations",
+    _: "Include customer %{integrationPluralLower}",
+    integrationPluralLower: "integrations",
   },
   "input.instanceLabel": "Instance",
   "input.integrationLabel": {
@@ -375,8 +375,8 @@ export const inputPhrases: InputPhrases = {
     marketplaceSingular: "Marketplace",
   },
   "input.nameDisabledHelper.integration": {
-    _: "Name can only be updated in the ${integrationSingularLower} details.",
-    integrationSingularLower: "Integration",
+    _: "Name can only be updated in the %{integrationSingularLower} details.",
+    integrationSingularLower: "integration",
   },
   "input.nameLabel": "Name",
   "input.noOptionsValue": "No options found",

--- a/src/lib/shared/input.ts
+++ b/src/lib/shared/input.ts
@@ -25,8 +25,10 @@ export interface InputPhrases {
   /** English: "Category" */
   "input.categoryLabel": SimplePhrase;
 
-  /** English: "Category can only be updated in the integration details." */
-  "input.categoryDisabledHelper.integration": SimplePhrase;
+  /** English: "Category can only be updated in the ${integrationSingularLower} details." */
+  "input.categoryDisabledHelper.integration": ComplexPhrase<{
+    integrationSingularLower: string;
+  }> | SimplePhrase;
 
   /** English: "Edit" */
   "input.codePlaceholder": SimplePhrase;
@@ -55,8 +57,10 @@ export interface InputPhrases {
   /** English: "Description" */
   "input.descriptionLabel": SimplePhrase;
 
-  /** English: "Description can only be updated in the integration details." */
-  "input.descriptionDisabledHelper.integration": SimplePhrase;
+  /** English: "Description can only be updated in the ${integrationSingularLower} details." */
+  "input.descriptionDisabledHelper.integration": ComplexPhrase<{
+    integrationSingularLower: string;
+  }> | SimplePhrase;
 
   /** English: "Default value" */
   "input.defaultValueLabel": SimplePhrase;
@@ -83,7 +87,7 @@ export interface InputPhrases {
   "input.failedPreprocessFlowsOnlyLabel": SimplePhrase;
 
   /** English: "Search %{type}" */
-  "input.filterSearchPlaceholder": ComplexPhrase<{ type?: string }>;
+  "input.filterSearchPlaceholder": ComplexPhrase<{ type?: string, integrationPluralLower?: string }>;
 
   /** English: "Has outdated components" */
   "input.hasOutdatedComponentsLabel": SimplePhrase;
@@ -103,17 +107,23 @@ export interface InputPhrases {
   /** English: "Include customer components" */
   "input.includeCustomerComponentsLabel": SimplePhrase;
 
-  /** English: "Include customer integrations" */
-  "input.includeCustomerIntegrationsLabel": SimplePhrase;
+  /** English: "Include customer ${integrationPlural}" */
+  "input.includeCustomerIntegrationsLabel": ComplexPhrase<{
+    integrationPlural: string;
+  }> | SimplePhrase;
 
   /** English: "Instance" */
   "input.instanceLabel": SimplePhrase;
 
-  /** English: "Integration" */
-  "input.integrationLabel": SimplePhrase;
+  /** English: "${integrationSingular}" */
+  "input.integrationLabel": ComplexPhrase<{
+    integrationSingular: string;
+  }> | SimplePhrase;
 
-  /** English: "Integration version" */
-  "input.integrationVersionLabel": SimplePhrase;
+  /** English: "${integrationSingular} version" */
+  "input.integrationVersionLabel": ComplexPhrase<{
+    integrationSingular: string;
+  }> | SimplePhrase;
 
   /** English: "Designer version" */
   "input.integrationVersionLatestLabel": SimplePhrase;
@@ -145,14 +155,16 @@ export interface InputPhrases {
   /** English: "Log type" */
   "input.logTypeLabel": SimplePhrase;
 
-  /** English: "%{marketplaceName} version" */
-  "input.marketplaceVersionLabel": ComplexPhrase<{ marketplaceName?: string }>;
+  /** English: "${marketplaceSingular} version" */
+  "input.marketplaceVersionLabel": ComplexPhrase<{ marketplaceSingular?: string }>;
 
   /** English: "Name" */
   "input.nameLabel": SimplePhrase;
 
-  /** English: "Name can only be updated in the integration details."" */
-  "input.nameDisabledHelper.integration": SimplePhrase;
+  /** English: "Name can only be updated in the ${integrationSingularLower} details." */
+  "input.nameDisabledHelper.integration": ComplexPhrase<{
+    integrationSingularLower: string;
+  }> | SimplePhrase;
 
   /** English: "No options found" */
   "input.noOptionsValue": SimplePhrase;
@@ -298,8 +310,10 @@ export const inputPhrases: InputPhrases = {
   "input.apiKeyAddButton": "Add API key",
   "input.apiKeyLabel": "API key",
   "input.apiKeyPlaceholder": "No API key configured",
-  "input.categoryDisabledHelper.integration":
-    "Category can only be updated in the integration details.",
+  "input.categoryDisabledHelper.integration": {
+    _: "Category can only be updated in the ${integrationSingularLower} details.",
+    integrationSingularLower: "Integration",
+  },
   "input.categoryLabel": "Category",
   "input.codePlaceholder": "Edit",
   "input.commentLabel": "Comment",
@@ -310,8 +324,10 @@ export const inputPhrases: InputPhrases = {
   "input.dateError": "There was an error",
   "input.dateTimeError": "There was an error",
   "input.defaultValueLabel": "Default value",
-  "input.descriptionDisabledHelper.integration":
-    "Description can only be updated in the integration details.",
+  "input.descriptionDisabledHelper.integration": {
+    _: "Description can only be updated in the ${integrationSingularLower} details.",
+    integrationSingularLower: "Integration",
+  },
   "input.descriptionLabel": "Description",
   "input.disableLogsLabel": "Disable logs",
   "input.disableStepOutputsLabel": "Disable step outputs",
@@ -330,10 +346,19 @@ export const inputPhrases: InputPhrases = {
   "input.headersLabel": "Headers",
   "input.headersValueLabel": "Value",
   "input.includeCustomerComponentsLabel": "Include customer components",
-  "input.includeCustomerIntegrationsLabel": "Include customer integrations",
+  "input.includeCustomerIntegrationsLabel": {
+    _: "Include customer %{integrationPlural}",
+    integrationPlural: "Integrations",
+  },
   "input.instanceLabel": "Instance",
-  "input.integrationLabel": "Integration",
-  "input.integrationVersionLabel": "Integration version",
+  "input.integrationLabel": {
+    _: "%{integrationSingular}",
+    integrationSingular: "Integration",
+  },
+  "input.integrationVersionLabel": {
+    _: "%{integrationSingular} version",
+    integrationSingular: "Integration",
+  },
   "input.integrationVersionLatestLabel": "Designer version",
   "input.keyLabel": "Key",
   "input.keyPlaceholder": "Key",
@@ -346,11 +371,13 @@ export const inputPhrases: InputPhrases = {
   "input.logType.integrationExecutionValue": "Execution Only",
   "input.logTypeLabel": "Log type",
   "input.marketplaceVersionLabel": {
-    _: "%{marketplaceName} version",
-    marketplaceName: "Marketplace",
+    _: "%{marketplaceSingular} version",
+    marketplaceSingular: "Marketplace",
   },
-  "input.nameDisabledHelper.integration":
-    "Name can only be updated in the integration details.",
+  "input.nameDisabledHelper.integration": {
+    _: "Name can only be updated in the ${integrationSingularLower} details.",
+    integrationSingularLower: "Integration",
+  },
   "input.nameLabel": "Name",
   "input.noOptionsValue": "No options found",
   "input.noneValue": "None",

--- a/src/lib/shared/tab.ts
+++ b/src/lib/shared/tab.ts
@@ -13,6 +13,9 @@ export interface TabPhrases {
   /** English: "User Configuration" */
   "configurationTab.title": SimplePhrase;
 
+  /** English: "Connections" */
+  "connectionsTab.title": SimplePhrase;
+
   /** English: "Credentials" */
   "credentialsTab.title": SimplePhrase;
 
@@ -26,10 +29,14 @@ export interface TabPhrases {
   "instancesTab.title": SimplePhrase;
 
   /** English: "Integrations" */
-  "integrationsTab.title": SimplePhrase;
+  "integrationsTab.title": ComplexPhrase<{
+    integrationPlural: string;
+  }> | SimplePhrase;
 
   /** English: "Marketplace" */
-  "marketplaceTab.title": SimplePhrase;
+  "marketplaceTab.title": ComplexPhrase<{
+    marketplaceSingular: string;
+  }> | SimplePhrase;
 
   /** English: "Payload" */
   "payloadTab.title": SimplePhrase;
@@ -139,12 +146,19 @@ export const tabPhrases: TabPhrases = {
   "attachmentsTab.title": "Attachments",
   "componentsTab.title": "Components",
   "configurationTab.title": "User Configuration",
+  "connectionsTab.title": "Connections",
   "credentialsTab.title": "Credentials",
   "detailsTab.title": "Details",
   "executionsTab.title": "Executions",
   "instancesTab.title": "Instances",
-  "integrationsTab.title": "Integrations",
-  "marketplaceTab.title": "Marketplace",
+  "integrationsTab.title": {
+    _: "%{integrationPlural}",
+    integrationPlural: "Integrations",
+  },
+  "marketplaceTab.title": {
+    _: "%{marketplaceSingular}",
+    marketplaceSingular: "Marketplace",
+  },
   "payloadTab.title": "Payload",
   "summaryTab.title": "Summary",
   "teamMembersTab.title": "Team Members",

--- a/src/lib/shared/tooltip.ts
+++ b/src/lib/shared/tooltip.ts
@@ -25,14 +25,15 @@ export interface TooltipPhrases {
   /** English: "Copy URL to clipboard" */
   "tooltip.copyUrl": SimplePhrase;
 
-  /** English: "Upgrade the %{marketplaceName} configuration to this latest published version." */
+  /** English: "Upgrade the ${marketplaceSingular} configuration to this latest published version." */
   "tooltip.marketplaceVersion": ComplexPhrase<{
-    marketplaceName?: string;
+    marketplaceSingular?: string;
   }>;
 
-  /** English: "A new version "v${latestVersion}" is available for integration." */
+  /** English: "A new version "v${latestVersion}" is available for this ${integrationSingularLower}." */
   "tooltip.newIntegrationVersionAvailable": ComplexPhrase<{
     latestVersion?: number;
+    integrationSingularLower?: string;
   }>;
 
   /** English: "Pass this API key via an HTTP header" */
@@ -52,11 +53,12 @@ export const tooltipPhrases: TooltipPhrases = {
   "tooltip.copyPayload": "Copy payload to clipboard",
   "tooltip.copyUrl": "Copy URL to clipboard",
   "tooltip.marketplaceVersion": {
-    _: "Upgrade the %{marketplaceName} configuration to this latest published version.",
-    marketplaceName: "Marketplace",
+    _: "Upgrade the %{marketplaceSingular} configuration to this latest published version.",
+    marketplaceSingular: "Marketplace",
   },
   "tooltip.newIntegrationVersionAvailable": {
-    _: `A new version "v%{latestVersion}" is available for integration.`,
+    _: `A new version "v%{latestVersion}" is available for this %{integrationSingularLower}.`,
+    integrationSingularLower: "Integration",
   },
   "tooltip.passApiKeyToHeader": "Pass this API key via an HTTP header",
   "tooltip.restoreDefault": "Restore default",

--- a/src/lib/shared/tooltip.ts
+++ b/src/lib/shared/tooltip.ts
@@ -25,12 +25,12 @@ export interface TooltipPhrases {
   /** English: "Copy URL to clipboard" */
   "tooltip.copyUrl": SimplePhrase;
 
-  /** English: "Upgrade the ${marketplaceSingular} configuration to this latest published version." */
+  /** English: "Upgrade the %{marketplaceSingular} configuration to this latest published version." */
   "tooltip.marketplaceVersion": ComplexPhrase<{
     marketplaceSingular?: string;
   }>;
 
-  /** English: "A new version "v${latestVersion}" is available for this ${integrationSingularLower}." */
+  /** English: "A new version "v%{latestVersion}" is available for this %{integrationSingularLower}." */
   "tooltip.newIntegrationVersionAvailable": ComplexPhrase<{
     latestVersion?: number;
     integrationSingularLower?: string;
@@ -58,7 +58,7 @@ export const tooltipPhrases: TooltipPhrases = {
   },
   "tooltip.newIntegrationVersionAvailable": {
     _: `A new version "v%{latestVersion}" is available for this %{integrationSingularLower}.`,
-    integrationSingularLower: "Integration",
+    integrationSingularLower: "integration",
   },
   "tooltip.passApiKeyToHeader": "Pass this API key via an HTTP header",
   "tooltip.restoreDefault": "Restore default",

--- a/src/lib/shared/user.ts
+++ b/src/lib/shared/user.ts
@@ -1,4 +1,4 @@
-import { SimplePhrase } from "../../types";
+import { ComplexPhrase, SimplePhrase } from "../../types";
 
 export interface UserPhrases {
   /** English: "Admin" */
@@ -20,10 +20,14 @@ export interface UserPhrases {
   "user.integratorRole": SimplePhrase;
 
   /** English: "Marketplace" */
-  "user.marketplaceRole": SimplePhrase;
+  "user.marketplaceRole": ComplexPhrase<{
+    marketplaceSingular: string;
+  }> | SimplePhrase;
 
   /** English: "Marketplace User" */
-  "user.marketplaceUserRole": SimplePhrase;
+  "user.marketplaceUserRole": ComplexPhrase<{
+    marketplaceSingular: string;
+  }> | SimplePhrase;
 
   /** English: "Third-Party" */
   "user.thirdPartyRole": SimplePhrase;
@@ -34,8 +38,14 @@ export const userPhrases: UserPhrases = {
   "user.customerManagerRole": "Customer Manager",
   "user.guestRole": "Guest",
   "user.integratorRole": "Integrator",
-  "user.marketplaceRole": "Marketplace",
-  "user.marketplaceUserRole": "Marketplace User",
+  "user.marketplaceRole": {
+    _: "%{marketplaceSingular}",
+    marketplaceSingular: "Marketplace"
+  },
+  "user.marketplaceUserRole": {
+    _: "%{marketplaceSingular} User",
+    marketplaceSingular: "Marketplace"
+  },
   "user.memberRole": "Member",
   "user.ownerRole": "Owner",
   "user.thirdPartyRole": "Third-Party",

--- a/src/lib/unique/components.ts
+++ b/src/lib/unique/components.ts
@@ -1,6 +1,10 @@
 import { NamespacedSharedAndUniquePhrases } from "../../types";
+import { SimplePhrase } from "../../types";
 
-export interface ComponentsPhrases {}
+export interface ComponentsPhrases {
+  /** English: "Components" */
+  "components__filterBar.title": SimplePhrase;
+}
 
 export const componentsPhrases: NamespacedSharedAndUniquePhrases<ComponentsPhrases> =
   {

--- a/src/lib/unique/dashboard.ts
+++ b/src/lib/unique/dashboard.ts
@@ -1,6 +1,10 @@
 import { NamespacedSharedAndUniquePhrases } from "../../types";
+import { SimplePhrase } from "../../types";
 
-export interface DashboardPhrases {}
+export interface DashboardPhrases {
+  /** English: "Dashboard" */
+  "dashboard__filterBar.title": SimplePhrase;
+}
 
 export const dashboardPhrases: NamespacedSharedAndUniquePhrases<DashboardPhrases> =
   {

--- a/src/lib/unique/integration-marketplace.ts
+++ b/src/lib/unique/integration-marketplace.ts
@@ -1,4 +1,4 @@
-import { NamespacedSharedAndUniquePhrases, SimplePhrase } from "../../types";
+import { NamespacedSharedAndUniquePhrases, ComplexPhrase, SimplePhrase } from "../../types";
 
 export interface IntegrationMarketplacePhrases {
   /** English: "Activated but not configured" */
@@ -19,14 +19,25 @@ export interface IntegrationMarketplacePhrases {
   /** English: "All" */
   "integration-marketplace__filterBar.allButton": SimplePhrase;
 
-  /** English: "Integration is not configured." */
-  "integration-marketplace.instanceUnconfiguredTooltip": SimplePhrase;
+  /** English: "${marketplaceSingular}" */
+  "integration-marketplace__filterBar.title": ComplexPhrase<{
+    marketplaceSingular: string;
+  }> | SimplePhrase;
 
-  /** English: "Integration is paused." */
-  "integration-marketplace.instancePausedTooltip": SimplePhrase;
+  /** English: "${integrationSingular} is not configured." */
+  "integration-marketplace.instanceUnconfiguredTooltip": ComplexPhrase<{
+    integrationSingular: string;
+  }> | SimplePhrase;
 
-  /** English: "Integration is activated." */
-  "integration-marketplace.instanceActivatedTooltip": SimplePhrase;
+  /** English: "${integrationSingular} is paused." */
+  "integration-marketplace.instancePausedTooltip": ComplexPhrase<{
+    integrationSingular: string;
+  }> | SimplePhrase;
+
+  /** English: "${integrationSingular} is activated." */
+  "integration-marketplace.instanceActivatedTooltip": ComplexPhrase<{
+    integrationSingular: string;
+  }> | SimplePhrase;
 
   /** English: "Current user is not configured." */
   "integration-marketplace.userUnconfiguredTooltip": SimplePhrase;
@@ -49,14 +60,24 @@ export interface IntegrationMarketplacePhrases {
   /** English: "All users are activated." */
   "integration-marketplace.usersActivatedTooltip": SimplePhrase;
 
-  /** English: "Add Integration" */
-  "integration-marketplace.addIntegrationDialog.buttonText": SimplePhrase;
+  /** English: "Add ${integrationSingular}" */
+  "integration-marketplace.addIntegrationDialog.buttonText": ComplexPhrase<{
+    integrationSingular: string;
+  }> | SimplePhrase;
 
-  /** English: "Select Integration" */
-  "integration-marketplace.addIntegrationDialog.title": SimplePhrase;
+  /** English: "Select ${integrationSingular}" */
+  "integration-marketplace.addIntegrationDialog.title": ComplexPhrase<{
+    integrationSingular: string;
+  }> | SimplePhrase;
 
-  /** English: "Only published integrations can be used to create an instance." */
-  "integration-marketplace.integrationPicker.text": SimplePhrase;
+  /** English: "Only published %{integrationPluralLower} can be used to create an instance." */
+  "integration-marketplace.integrationPicker.text": ComplexPhrase<{
+    integrationPluralLower: string;
+  }> | SimplePhrase;
+
+  "integration-marketplace__input.filterSearchPlaceholder": ComplexPhrase<{
+    integrationPluralLower?: string;
+  }> | SimplePhrase;
 }
 
 export const integrationMarketplacePhrases: NamespacedSharedAndUniquePhrases<IntegrationMarketplacePhrases> =
@@ -69,18 +90,29 @@ export const integrationMarketplacePhrases: NamespacedSharedAndUniquePhrases<Int
       "Activated but not configured",
     "integration-marketplace__filterBar.activateButton": "Activated",
     "integration-marketplace__filterBar.allButton": "All",
-    "integration-marketplace__filterBar.title": "Marketplace",
+    "integration-marketplace__filterBar.title": {
+      _: "%{marketplaceSingular}",
+      marketplaceSingular: "Marketplace",
+    },
     "integration-marketplace__filterResults.placeholderText":
       "Click the add integration button to add an integration.",
     "integration-marketplace__filterResults.placeholderTitle": "integrations",
     "integration-marketplace__input.filterSearchPlaceholder": {
-      _: "Search integrations",
+      _: "Search %{integrationPluralLower}",
+      integrationPluralLower: "integrations",
     },
-    "integration-marketplace.instanceUnconfiguredTooltip":
-      "Integration is not configured.",
-    "integration-marketplace.instancePausedTooltip": "Integration is paused.",
-    "integration-marketplace.instanceActivatedTooltip":
-      "Integration is activated.",
+    "integration-marketplace.instanceUnconfiguredTooltip": {
+      _: "%{integrationSingular} is not configured.",
+      integrationSingular: "Integration",
+    },
+    "integration-marketplace.instancePausedTooltip": {
+      _: "%{integrationSingular} is paused.",
+      integrationSingular: "Integration",
+    },
+    "integration-marketplace.instanceActivatedTooltip": {
+      _: "%{integrationSingular} is activated.",
+      integrationSingular: "Integration",
+    },
     "integration-marketplace.userUnconfiguredTooltip":
       "Current user is not configured.",
     "integration-marketplace.userActivatedTooltip":
@@ -94,9 +126,16 @@ export const integrationMarketplacePhrases: NamespacedSharedAndUniquePhrases<Int
     "integration-marketplace.usersUnconfiguredTooltip":
       "At least one instance is not configured for current user.",
     "integration-marketplace.usersActivatedTooltip": "All users are activated.",
-    "integration-marketplace.addIntegrationDialog.buttonText":
-      "Add Integration",
-    "integration-marketplace.addIntegrationDialog.title": "Select Integration",
-    "integration-marketplace.integrationPicker.text":
-      "Only published integrations can be used to create an instance.",
+    "integration-marketplace.addIntegrationDialog.buttonText": {
+      _: "Add %{integrationSingular}",
+      integrationSingular: "Integration",
+    },
+    "integration-marketplace.addIntegrationDialog.title": {
+      _: "Select %{integrationSingular}",
+      integrationSingular: "Integration",
+    },
+    "integration-marketplace.integrationPicker.text": {
+      _: "Only published %{integrationPlural} can be used to create an instance.",
+      integrationPluralLower: "integrations",
+    }
   };

--- a/src/lib/unique/integration-marketplace.ts
+++ b/src/lib/unique/integration-marketplace.ts
@@ -19,22 +19,22 @@ export interface IntegrationMarketplacePhrases {
   /** English: "All" */
   "integration-marketplace__filterBar.allButton": SimplePhrase;
 
-  /** English: "${marketplaceSingular}" */
+  /** English: "%{marketplaceSingular}" */
   "integration-marketplace__filterBar.title": ComplexPhrase<{
     marketplaceSingular: string;
   }> | SimplePhrase;
 
-  /** English: "${integrationSingular} is not configured." */
+  /** English: "%{integrationSingular} is not configured." */
   "integration-marketplace.instanceUnconfiguredTooltip": ComplexPhrase<{
     integrationSingular: string;
   }> | SimplePhrase;
 
-  /** English: "${integrationSingular} is paused." */
+  /** English: "%{integrationSingular} is paused." */
   "integration-marketplace.instancePausedTooltip": ComplexPhrase<{
     integrationSingular: string;
   }> | SimplePhrase;
 
-  /** English: "${integrationSingular} is activated." */
+  /** English: "%{integrationSingular} is activated." */
   "integration-marketplace.instanceActivatedTooltip": ComplexPhrase<{
     integrationSingular: string;
   }> | SimplePhrase;
@@ -60,12 +60,12 @@ export interface IntegrationMarketplacePhrases {
   /** English: "All users are activated." */
   "integration-marketplace.usersActivatedTooltip": SimplePhrase;
 
-  /** English: "Add ${integrationSingular}" */
+  /** English: "Add %{integrationSingular}" */
   "integration-marketplace.addIntegrationDialog.buttonText": ComplexPhrase<{
     integrationSingular: string;
   }> | SimplePhrase;
 
-  /** English: "Select ${integrationSingular}" */
+  /** English: "Select %{integrationSingular}" */
   "integration-marketplace.addIntegrationDialog.title": ComplexPhrase<{
     integrationSingular: string;
   }> | SimplePhrase;
@@ -135,7 +135,7 @@ export const integrationMarketplacePhrases: NamespacedSharedAndUniquePhrases<Int
       integrationSingular: "Integration",
     },
     "integration-marketplace.integrationPicker.text": {
-      _: "Only published %{integrationPlural} can be used to create an instance.",
+      _: "Only published %{integrationPluralLower} can be used to create an instance.",
       integrationPluralLower: "integrations",
     }
   };

--- a/src/lib/unique/integration.id.ts
+++ b/src/lib/unique/integration.id.ts
@@ -5,27 +5,36 @@ import {
 } from "../../types";
 
 export interface IntegrationIdPhrases {
-  /** English: "Please contact %{organization} to activate this integration." */
+  /** English: "Please contact ${organization} to activate this ${integrationSingularLower}." */
   "integrations.id__banner.customerActivateText": ComplexPhrase<{
+    integrationSingularLower: string;
     organization: string;
   }>;
 
-  /** English: "Please contact %{organization} to update to latest version." */
+  /** English: "Please contact ${organization} to update to latest version." */
   "integrations.id__banner.customerUpdateText": ComplexPhrase<{
     organization: string;
   }>;
 
-  /** English: "Your integration is enabled" */
-  "integrations.id__banner.enabledText": SimplePhrase;
+  /** English: "Your ${integrationSingularLower} is enabled" */
+  "integrations.id__banner.enabledText": ComplexPhrase<{
+    integrationSingularLower: string;
+  }> | SimplePhrase;
 
-  /** English: "Pause Integration" */
-  "integrations.id__banner.pauseButton": SimplePhrase;
+  /** English: "Pause ${integrationSingular}" */
+  "integrations.id__banner.pauseButton": ComplexPhrase<{
+    integrationSingular: string;
+  }> | SimplePhrase;
 
-  /** English: "Your integration is paused" */
-  "integrations.id__banner.pausedText": SimplePhrase;
+  /** English: "Your ${integrationSingularLower} is paused" */
+  "integrations.id__banner.pausedText": ComplexPhrase<{
+    integrationSingularLower: string;
+  }> | SimplePhrase;
 
-  /** English: "Unpause Integration" */
-  "integrations.id__banner.unpauseButton": SimplePhrase;
+  /** English: "Unpause ${integrationSingular}" */
+  "integrations.id__banner.unpauseButton": ComplexPhrase<{
+    integrationSingular: string;
+  }> | SimplePhrase;
 
   /** English: "Update" */
   "integrations.id__banner.updateButton": SimplePhrase;
@@ -48,8 +57,10 @@ export interface IntegrationIdPhrases {
   /** English: "View User Level Configuration" */
   "integrations.id__filterBar.viewUserConfigurationButton": SimplePhrase;
 
-  /** English: This integration has a new version. Previous versions are read-only. */
-  "integrations.id__newVersionBanner.newVersionText": SimplePhrase;
+  /** English: This ${integrationSingularLower} has a new version. Previous versions are read-only. */
+  "integrations.id__newVersionBanner.newVersionText": ComplexPhrase<{
+    integrationSingularLower: string;
+  }> | SimplePhrase;
 
   /** English: "View Current" */
   "integrations.id__newVersionBanner.viewCurrentButton": SimplePhrase;
@@ -58,17 +69,30 @@ export interface IntegrationIdPhrases {
 export const integrationIdPhrases: NamespacedSharedAndUniquePhrases<IntegrationIdPhrases> =
   {
     "integrations.id__banner.customerActivateText": {
-      _: "Please contact %{organization} to activate this integration.",
+      _: "Please contact %{organization} to activate this %{integrationSingularLower}.",
       organization: "organization",
+      integrationSingularLower: "integration",
     },
     "integrations.id__banner.customerUpdateText": {
       _: "Please contact %{organization} to update to latest version.",
       organization: "organization",
     },
-    "integrations.id__banner.enabledText": "Your integration is enabled",
-    "integrations.id__banner.pauseButton": "Pause Integration",
-    "integrations.id__banner.pausedText": "Your integration is paused",
-    "integrations.id__banner.unpauseButton": "Unpause Integration",
+    "integrations.id__banner.enabledText": {
+      _: "Your %{integrationSingularLower} is enabled",
+      integrationSingularLower: "integration",
+    },
+    "integrations.id__banner.pauseButton": {
+      _: "Pause %{integrationSingular}",
+      integrationSingular: "Integration",
+    },
+    "integrations.id__banner.pausedText": {
+      _: "Your %{integrationSingularLower} is paused",
+      integrationSingularLower: "Integration",
+    },
+    "integrations.id__banner.unpauseButton": {
+      _: "Unpause %{integrationSingular}",
+      integrationSingular: "Integration",
+    },
     "integrations.id__banner.updateButton": "Update",
     "integrations.id__banner.updateText": "There is an update available",
     "integrations.id__filterBar.configureUserButton":
@@ -79,7 +103,9 @@ export const integrationIdPhrases: NamespacedSharedAndUniquePhrases<IntegrationI
     "integrations.id__filterBar.viewConfigurationButton": "View Configuration",
     "integrations.id__filterBar.viewUserConfigurationButton":
       "View User Level Configuration",
-    "integrations.id__newVersionBanner.newVersionText":
-      "This integration has a new version. Previous versions are read-only.",
+    "integrations.id__newVersionBanner.newVersionText": {
+      _: "This %{integrationSingularLower} has a new version. Previous versions are read-only.",
+      integrationSingularLower: "integration",
+    },
     "integrations.id__newVersionBanner.viewCurrentButton": "View Current",
   };

--- a/src/lib/unique/integration.id.ts
+++ b/src/lib/unique/integration.id.ts
@@ -5,33 +5,33 @@ import {
 } from "../../types";
 
 export interface IntegrationIdPhrases {
-  /** English: "Please contact ${organization} to activate this ${integrationSingularLower}." */
+  /** English: "Please contact %{organization} to activate this %{integrationSingularLower}." */
   "integrations.id__banner.customerActivateText": ComplexPhrase<{
     integrationSingularLower: string;
     organization: string;
   }>;
 
-  /** English: "Please contact ${organization} to update to latest version." */
+  /** English: "Please contact %{organization} to update to latest version." */
   "integrations.id__banner.customerUpdateText": ComplexPhrase<{
     organization: string;
   }>;
 
-  /** English: "Your ${integrationSingularLower} is enabled" */
+  /** English: "Your %{integrationSingularLower} is enabled" */
   "integrations.id__banner.enabledText": ComplexPhrase<{
     integrationSingularLower: string;
   }> | SimplePhrase;
 
-  /** English: "Pause ${integrationSingular}" */
+  /** English: "Pause %{integrationSingular}" */
   "integrations.id__banner.pauseButton": ComplexPhrase<{
     integrationSingular: string;
   }> | SimplePhrase;
 
-  /** English: "Your ${integrationSingularLower} is paused" */
+  /** English: "Your %{integrationSingularLower} is paused" */
   "integrations.id__banner.pausedText": ComplexPhrase<{
     integrationSingularLower: string;
   }> | SimplePhrase;
 
-  /** English: "Unpause ${integrationSingular}" */
+  /** English: "Unpause %{integrationSingular}" */
   "integrations.id__banner.unpauseButton": ComplexPhrase<{
     integrationSingular: string;
   }> | SimplePhrase;
@@ -57,7 +57,7 @@ export interface IntegrationIdPhrases {
   /** English: "View User Level Configuration" */
   "integrations.id__filterBar.viewUserConfigurationButton": SimplePhrase;
 
-  /** English: This ${integrationSingularLower} has a new version. Previous versions are read-only. */
+  /** English: This %{integrationSingularLower} has a new version. Previous versions are read-only. */
   "integrations.id__newVersionBanner.newVersionText": ComplexPhrase<{
     integrationSingularLower: string;
   }> | SimplePhrase;
@@ -87,7 +87,7 @@ export const integrationIdPhrases: NamespacedSharedAndUniquePhrases<IntegrationI
     },
     "integrations.id__banner.pausedText": {
       _: "Your %{integrationSingularLower} is paused",
-      integrationSingularLower: "Integration",
+      integrationSingularLower: "integration",
     },
     "integrations.id__banner.unpauseButton": {
       _: "Unpause %{integrationSingular}",

--- a/src/lib/unique/integrations.ts
+++ b/src/lib/unique/integrations.ts
@@ -1,12 +1,12 @@
 import { ComplexPhrase, NamespacedSharedAndUniquePhrases, SimplePhrase } from "../../types";
 
 export interface IntegrationsPhrases {
-  /** English: "${integrationPlural}" */
+  /** English: "%{integrationPlural}" */
   "integrations__filterBar.title": ComplexPhrase<{
     integrationPlural: string;
   }> | SimplePhrase;
 
-  /** English: "Add ${integrationSingular}" */
+  /** English: "Add %{integrationSingular}" */
   "integrations__filterBar.addButton": ComplexPhrase<{
     integrationSingular: string;
   }> | SimplePhrase;

--- a/src/lib/unique/integrations.ts
+++ b/src/lib/unique/integrations.ts
@@ -1,12 +1,26 @@
-import { NamespacedSharedAndUniquePhrases, SimplePhrase } from "../../types";
+import { ComplexPhrase, NamespacedSharedAndUniquePhrases, SimplePhrase } from "../../types";
 
 export interface IntegrationsPhrases {
-  /** English: "Add integration" */
-  "integrations__filterBar.addButton": SimplePhrase;
+  /** English: "${integrationPlural}" */
+  "integrations__filterBar.title": ComplexPhrase<{
+    integrationPlural: string;
+  }> | SimplePhrase;
+
+  /** English: "Add ${integrationSingular}" */
+  "integrations__filterBar.addButton": ComplexPhrase<{
+    integrationSingular: string;
+  }> | SimplePhrase;
 }
 
 export const integrationsPhrases: NamespacedSharedAndUniquePhrases<IntegrationsPhrases> =
   {
-    "integrations__filterBar.addButton": "Add integration",
-    "integrations__filterBar.title": "Integrations",
+    "integrations__filterBar.title": {
+      _: "%{integrationPlural}",
+      integrationPlural: "Integrations",
+    },
+
+    "integrations__filterBar.addButton": {
+      _: "Add %{integrationSingular}",
+      integrationSingular: "Integration",
+    },
   };


### PR DESCRIPTION
Set to version 2.0.0 b/c converting the `marketplaceName` argument to `marketplaceSingle` is a breaking change for some of these ComplexPhrases.