### PR TITLE
Add New Log Types to Logs Filter Bar and Deprecate Legacy Types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismatic-io/translations",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/translations",
-      "version": "2.1.3",
+      "version": "2.2.0",
       "license": "MIT",
       "devDependencies": {
         "prettier": "2.8.3",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/prismatic-io/translations.git"
   },
   "license": "MIT",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/lib/shared/dataTable.ts
+++ b/src/lib/shared/dataTable.ts
@@ -10,6 +10,9 @@ export interface DataTablePhrases {
   /** English: "Connection" */
   "dataTable.connectionLabel": SimplePhrase;
 
+  /** English: "Log Type" */
+  "dataTable.logTypeLabel": SimplePhrase;
+
   /** English: "Comments" */
   "dataTable.commentsLabel": SimplePhrase;
 
@@ -102,6 +105,7 @@ export const dataTablePhrases: DataTablePhrases = {
   "dataTable.activeInstancesLabel": "Active Instances",
   "dataTable.categoryLabel": "Category",
   "dataTable.connectionLabel": "Connection",
+  "dataTable.logTypeLabel": "Log Type",
   "dataTable.commentsLabel": "Comments",
   "dataTable.customerLabel": "Customer",
   "dataTable.defaultLabel": "Default",

--- a/src/lib/shared/input.ts
+++ b/src/lib/shared/input.ts
@@ -156,14 +156,38 @@ export interface InputPhrases {
   /** English: "Log severity" */
   "input.logSeverityLabel": SimplePhrase;
 
-  /** English: "Connection Only" */
+  /**
+   * English: "Connection Only"
+   * @deprecated Use `input.logType.connectionsValue` instead.
+   */
   "input.logType.integrationConnectionValue": SimplePhrase;
 
-  /** English: "Execution & Connection" */
+  /**
+   * English: "Execution & Connection"
+   * @deprecated Use `input.logType.allValue` instead.
+   */
   "input.logType.integrationExecutionAndConnectionValue": SimplePhrase;
 
-  /** English: "Execution only" */
+  /**
+   * English: "Execution only"
+   * @deprecated Use `input.logType.executionsValue` instead.
+   */
   "input.logType.integrationExecutionValue": SimplePhrase;
+
+  /** English: "All" */
+  "input.logType.allValue": SimplePhrase;
+
+  /** English: "Executions" */
+  "input.logType.executionsValue": SimplePhrase;
+
+  /** English: "Connections" */
+  "input.logType.connectionsValue": SimplePhrase;
+
+  /** English: "Management" */
+  "input.logType.managementValue": SimplePhrase;
+
+  /** English: "Data Sources" */
+  "input.logType.dataSourcesValue": SimplePhrase;
 
   /** English: "Log type" */
   "input.logTypeLabel": SimplePhrase;
@@ -395,6 +419,11 @@ export const inputPhrases: InputPhrases = {
   "input.logType.integrationExecutionAndConnectionValue":
     "Execution & Connection",
   "input.logType.integrationExecutionValue": "Execution Only",
+  "input.logType.allValue": "All",
+  "input.logType.executionsValue": "Executions",
+  "input.logType.connectionsValue": "Connections",
+  "input.logType.managementValue": "Management",
+  "input.logType.dataSourcesValue": "Data Sources",
   "input.logTypeLabel": "Log type",
   "input.marketplaceVersionLabel": {
     _: "%{marketplaceSingular} version",


### PR DESCRIPTION
This PR introduces new log types in the filter bar, enhancing the flexibility and usability of log filtering. As part of this change, we are deprecating some existing log types and replacing them with more generic and standardized options in the codebase.

The older log types have been marked as deprecated. Users accessing these deprecated types through the Embedded SDK will receive TypeScript hints notifying them of the deprecations and providing the new log types they need to use.