### PR TITLE
Add config wizard data source reset phrases

### DIFF
--- a/src/lib/shared/dialog.ts
+++ b/src/lib/shared/dialog.ts
@@ -129,6 +129,12 @@ export interface DialogPhrases {
     organizationName: string;
   }>;
 
+  /** English: "Do you want to reset this value to the data source result?" */
+  "configurationWizardDialog.dataSourceResetText": SimplePhrase;
+
+  /** English: "Reset" */
+  "configurationWizardDialog.dataSourceResetButton": SimplePhrase;
+
   /** English: "Cancel" */
   "apiKeyDialog.cancelButton": SimplePhrase;
 
@@ -347,6 +353,9 @@ export const dialogPhrases: DialogPhrases = {
     _: "This page contains non-visible config variables that need to be set by %{organizationName} before continuing.",
     organizationName: "the organization",
   },
+  "configurationWizardDialog.dataSourceResetText":
+    "Do you want to reset this value to the data source result?",
+  "configurationWizardDialog.dataSourceResetButton": "Reset",
 
   // api key dialog
   "apiKeyDialog.cancelButton": "Cancel",

--- a/src/lib/shared/dialog.ts
+++ b/src/lib/shared/dialog.ts
@@ -129,7 +129,7 @@ export interface DialogPhrases {
     organizationName: string;
   }>;
 
-  /** English: "Do you want to reset this value to the data source result?" */
+  /** English: "Do you want to reset this value to the latest value?" */
   "configurationWizardDialog.dataSourceResetText": SimplePhrase;
 
   /** English: "Reset" */

--- a/src/lib/shared/dialog.ts
+++ b/src/lib/shared/dialog.ts
@@ -354,7 +354,7 @@ export const dialogPhrases: DialogPhrases = {
     organizationName: "the organization",
   },
   "configurationWizardDialog.dataSourceResetText":
-    "Do you want to reset this value to the data source result?",
+    "Do you want to reset this value to the latest value?",
   "configurationWizardDialog.dataSourceResetButton": "Reset",
 
   // api key dialog


### PR DESCRIPTION
# What
Add configurationWizardDialog.dataSourceResetText and configurationWizardDialog.dataSourceResetButton for the scalar data source reset prompt shown in the config wizard. 

# Why
We now will support setting how you'd like your data source to update your config variables in an analogous fashion to JSON Forms. 