### PR TITLE
Add user-activated connection warning phrases and reword connection usage copy

### DIFF
--- a/src/lib/shared/configWizard.ts
+++ b/src/lib/shared/configWizard.ts
@@ -115,13 +115,13 @@ export interface ConfigWizardPhrases {
   /** English: "Disconnecting this connection will apply to all locations where it's used. This may cause those locations to stop working as expected." */
   "configWizard.configPage.connection.disconnect.confirmation.message": SimplePhrase;
 
-  /** English: "Connection usage" */
+  /** English: "Connection Usage" */
   "configWizard.configPage.connection.usage.label": SimplePhrase;
 
   /** English: "Warning" */
   "configWizard.configPage.connection.usage.warning.label": SimplePhrase;
 
-  /** English: "Updates made to this shared connection will be applied to %{usageCount} other locations where it is used" */
+  /** English: "Other places use this connection too. Any change you save here applies to all of them, listed below." */
   "configWizard.configPage.connection.usage.warning": ComplexPhrase<{
     usageCount: number;
   }>;
@@ -199,10 +199,10 @@ export const configWizardPhrases: ConfigWizardPhrases = {
     "Disconnect Connection",
   "configWizard.configPage.connection.disconnect.confirmation.message":
     "Disconnecting this connection will apply to all locations where it's used. This may cause those locations to stop working as expected.",
-  "configWizard.configPage.connection.usage.label": "Connection usage",
+  "configWizard.configPage.connection.usage.label": "Connection Usage",
   "configWizard.configPage.connection.usage.warning.label": "Warning",
   "configWizard.configPage.connection.usage.warning": {
-    _: "Updates made to this shared connection will be applied to %{usageCount} other locations where it is used",
+    _: "Other places use this connection too. Any change you save here applies to all of them, listed below.",
     usageCount: 0,
   },
   "configWizard.configPage.connection.name.label": "Name",

--- a/src/lib/shared/dataTable.ts
+++ b/src/lib/shared/dataTable.ts
@@ -19,6 +19,9 @@ export interface DataTablePhrases {
   /** English: "Comments" */
   "dataTable.commentsLabel": SimplePhrase;
 
+  /** English: "Created on" */
+  "dataTable.createdOnLabel": SimplePhrase;
+
   /** English: "Customer" */
   "dataTable.customerLabel": SimplePhrase;
 
@@ -66,6 +69,9 @@ export interface DataTablePhrases {
 
   /** English: "Last triggered" */
   "dataTable.lastTriggeredAtLabel": SimplePhrase;
+
+  /** English: "Location" */
+  "dataTable.locationLabel": SimplePhrase;
 
   /** English: "Message" */
   "dataTable.messageLabel": SimplePhrase;
@@ -174,6 +180,7 @@ export const dataTablePhrases: DataTablePhrases = {
   "dataTable.logTypeLabel": "Type",
   "dataTable.commentsLabel": "Comments",
   "dataTable.configVariableLabel": "Config Variable",
+  "dataTable.createdOnLabel": "Created on",
   "dataTable.customerLabel": "Customer",
   "dataTable.defaultLabel": "Default",
   "dataTable.descriptionLabel": "Description",
@@ -191,6 +198,7 @@ export const dataTablePhrases: DataTablePhrases = {
   "dataTable.labelsLabel": "Labels",
   "dataTable.lastTriggeredAtLabel": "Last triggered",
   "dataTable.lastRunLabel": "Last run",
+  "dataTable.locationLabel": "Location",
   "dataTable.messageLabel": "Message",
   "dataTable.nameLabel": "Name",
   "dataTable.requiredLabel": "Required",

--- a/src/lib/shared/dialog.ts
+++ b/src/lib/shared/dialog.ts
@@ -129,6 +129,11 @@ export interface DialogPhrases {
     organizationName: string;
   }>;
 
+  /** English: "Each user will need to connect their own account before this %{integrationSingularLower} will run." */
+  "configurationWizardDialog.userLevelConnectionsWarningText": ComplexPhrase<{
+    integrationSingularLower: string;
+  }>;
+
   /** English: "Do you want to reset this value to the latest value?" */
   "configurationWizardDialog.dataSourceResetText": SimplePhrase;
 
@@ -352,6 +357,10 @@ export const dialogPhrases: DialogPhrases = {
   "configurationWizardDialog.missingEmbeddedConfigVariablesWarningText": {
     _: "This page contains non-visible config variables that need to be set by %{organizationName} before continuing.",
     organizationName: "the organization",
+  },
+  "configurationWizardDialog.userLevelConnectionsWarningText": {
+    _: "Each user will need to connect their own account before this %{integrationSingularLower} will run.",
+    integrationSingularLower: "integration",
   },
   "configurationWizardDialog.dataSourceResetText":
     "Do you want to reset this value to the latest value?",

--- a/src/lib/unique/integration.id.ts
+++ b/src/lib/unique/integration.id.ts
@@ -59,6 +59,11 @@ export interface IntegrationIdPhrases {
   /** English: "There is an update available" */
   "integrations.id__banner.updateText": SimplePhrase;
 
+  /** English: "Each user will need to connect their own account before this %{integrationSingularLower} will run." */
+  "integrations.id__banner.userLevelConnectionsText": ComplexPhrase<{
+    integrationSingularLower: string;
+  }>;
+
   /** English: "Configure User Level Configuration" */
   "integrations.id__filterBar.configureUserButton": SimplePhrase;
 
@@ -118,6 +123,10 @@ export const integrationIdPhrases: NamespacedSharedAndUniquePhrases<IntegrationI
       "This will cancel any pending configuration changes and upgrade to the newest version.",
     "integrations.id__banner.updateButton": "Update",
     "integrations.id__banner.updateText": "There is an update available",
+    "integrations.id__banner.userLevelConnectionsText": {
+      _: "Each user will need to connect their own account before this %{integrationSingularLower} will run.",
+      integrationSingularLower: "integration",
+    },
     "integrations.id__filterBar.configureUserButton":
       "Configure User Level Configuration",
     "integrations.id__filterBar.reconfigureButton": "Reconfigure",


### PR DESCRIPTION
## What

Two new phrases and two rewordings.

### New

| Key | Surface |
|---|---|
| `integrations.id__banner.userLevelConnectionsText` | Banner on the integration detail page |
| `configurationWizardDialog.userLevelConnectionsWarningText` | Tooltip in the configuration wizard |

Both read "Each user will need to connect their own account before this %{integrationSingularLower} will run."

The English is identical but the keys are separate on purpose. The configuration wizard opens from more than one place, so it needs an override point independent of the integration page's banner – otherwise rewording one silently rewords the other. That matches how the package already treats shared copy: 76 of 607 phrases share text across keys today, `Cancel` across ten.

### Reworded

- `configWizard.configPage.connection.usage.label` – "Connection usage" → "Connection Usage"
- `configWizard.configPage.connection.usage.warning` – now says a change applies everywhere the connection is used, rather than counting the other locations

The warning keeps its `usageCount` token even though the new copy no longer interpolates it, so existing callers keep compiling.

## Why

Deploy validation doesn't check whether an integration's connections are collected per person, and those connections are gathered on the user level pages – so nothing a deployer fills in mentions them. Without the warning the deployment looks complete and fails on its first run.

## Release

Needs a **minor** release: the new keys widen the exported interface.

## Checks

`typecheck`, `lint`, and `build` clean. Verified both phrases reach the built `dist` (`lib/unique/integration.id.d.ts`, `lib/shared/dialog.d.ts`). No test suite in this repo.
